### PR TITLE
1.13対応及びスポーンエッグに変換できるMOBを増やした

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,13 +24,13 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.12.2-R0.1-SNAPSHOT</version>
-            <scope>provided</scope>
+            <version>1.13.2-R0.1-SNAPSHOT</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>jp.minecraftuser</groupId>
             <artifactId>EcoFramework</artifactId>
-            <version>0.2</version>
+            <version>0.6</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>jp.minecraftuser</groupId>
     <artifactId>EcoEgg</artifactId>
-    <version>0.2</version>
+    <version>0.2_mod</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/jp/minecraftuser/ecoegg/config/LoaderMob.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/config/LoaderMob.java
@@ -2,193 +2,247 @@
 package jp.minecraftuser.ecoegg.config;
 
 import java.util.UUID;
+
 import jp.minecraftuser.ecoegg.EcoEgg;
 import org.bukkit.DyeColor;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.EnderDragon;
 import org.bukkit.entity.Horse;
 import org.bukkit.entity.Ocelot;
 import org.bukkit.entity.Rabbit;
 
 /**
  * MOB卵ファイルR/Wクラス
+ *
  * @author ecolight
  */
 public class LoaderMob extends LoaderYaml {
     private EcoEgg plg = null;
     private FileConfiguration list = null;
+
     public LoaderMob(EcoEgg plg, UUID id) {
-        super(plg,""+id.getMostSignificantBits()+"_"+id.getLeastSignificantBits()+".yml");
+        super(plg, "" + id.getMostSignificantBits() + "_" + id.getLeastSignificantBits() + ".yml");
         this.plg = plg;
         reloadCnf();
         list = getCnf();
         list.options().copyDefaults(true);
         saveCnf();
     }
+
     public void saveGen(String name, String type, String date) {
         list.set("gen_user", name);
         list.set("gen_type", type);
         list.set("gen_date", date);
         saveCnf();
     }
+
     public void saveUse(String name, String type, String date) {
         list.set("use_user", name);
         list.set("use_type", type);
         list.set("use_date", date);
         saveCnf();
     }
+
     public void saveDate(long date) {
         list.set("date", date);
         saveCnf();
     }
+
     public void setUsed(boolean b) {
         list.set("used", b);
         saveCnf();
     }
+
     public void setMobType(short typeid) {
         list.set("mobid", typeid);
         saveCnf();
     }
+
     public void setCustomName(String str) {
         list.set("name", str);
         saveCnf();
     }
+
     public void setMaxHealth(double num) {
         list.set("maxhealth", num);
         saveCnf();
     }
+
     public void setHealth(double num) {
         list.set("health", num);
         saveCnf();
     }
+
     public void setOwner(String str) {
         list.set("owner", str);
         saveCnf();
     }
+
     public void setMaxDomestication(int num) {
         list.set("maxdomestication", num);
         saveCnf();
     }
+
     public void setDomestication(int num) {
         list.set("domestication", num);
         saveCnf();
     }
+
     public void setAge(int num) {
         list.set("age", num);
         saveCnf();
     }
+
     public void setStyle(Horse.Style style) {
         list.set("style", style.name());
         saveCnf();
     }
+
     public void setColor(Horse.Color color) {
         list.set("color", color.name());
         saveCnf();
     }
+
     public void setVariant(Horse.Variant var) {
         list.set("variant", var.name());
         saveCnf();
     }
+
     public void setJumpStrength(double num) {
         list.set("jumpstrength", num);
         saveCnf();
     }
+
     public void setSpeed(double num) {
         list.set("speed", num);
         saveCnf();
     }
+
     public void setCollar(DyeColor collar) {
         list.set("collar", collar.name());
         saveCnf();
     }
+
     public void setCatType(Ocelot.Type cattype) {
         list.set("cattype", cattype.name());
         saveCnf();
     }
+
     public void setPower(boolean power) {
         list.set("power", power);
         saveCnf();
     }
+
     public void setRabbitType(Rabbit.Type rabbittype) {
         list.set("rabbittype", rabbittype.name());
         saveCnf();
     }
+
     public void setBleed(boolean bleed) {
         list.set("bleed", bleed);
         saveCnf();
     }
+
     public void setChild(boolean child) {
         list.set("child", child);
         saveCnf();
     }
+
     public void setAngry(boolean angry) {
         list.set("angry", angry);
         saveCnf();
+
     }
+
     //--------------------------------------------------------------------------
     public boolean getUsed() {
         return list.getBoolean("used");
     }
+
     public short getMobType() {
         return (short) list.getInt("mobid");
     }
+
     public String getCustomName() {
         return list.getString("name");
     }
+
     public double getMaxHealth() {
         return list.getDouble("maxhealth");
     }
+
     public double getHealth() {
         return list.getDouble("health");
     }
+
     public String getOwner() {
         return list.getString("owner");
     }
+
     public int getMaxDomestication() {
         return list.getInt("maxdomestication");
     }
+
     public int getDomestication() {
         return list.getInt("domestication");
     }
+
     public int getAge() {
         return list.getInt("age");
     }
+
     public Horse.Style getStyle() {
         return Horse.Style.valueOf(list.getString("style"));
     }
+
     public Horse.Color getColor() {
         return Horse.Color.valueOf(list.getString("color"));
     }
+
     public Horse.Variant getVariant() {
         return Horse.Variant.valueOf(list.getString("variant"));
     }
+
     public double getJumpStrength() {
         return list.getDouble("jumpstrength");
     }
+
     public double getSpeed() {
         return list.getDouble("speed");
     }
+
     public DyeColor getCollar() {
         return DyeColor.valueOf(list.getString("collar"));
     }
+
     public Ocelot.Type getCatType() {
         return Ocelot.Type.valueOf(list.getString("cattype"));
     }
+
     public boolean getPower() {
         return list.getBoolean("power");
     }
+
     public Rabbit.Type getRabbitType() {
         return Rabbit.Type.valueOf(list.getString("rabbittype"));
     }
+
     public boolean getBleed() {
         return list.getBoolean("bleed");
     }
+
     public boolean getChild() {
         return list.getBoolean("child");
     }
+
     public boolean getAngry() {
         return list.getBoolean("angry");
     }
+
     public long getDate() {
         return list.getLong("date");
     }
+
+    public String getGenType() { return list.getString("gen_type"); }
+
 }

--- a/src/main/java/jp/minecraftuser/ecoegg/config/LoaderYaml.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/config/LoaderYaml.java
@@ -1,59 +1,83 @@
-
 package jp.minecraftuser.ecoegg.config;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.Reader;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import jp.minecraftuser.ecoegg.EcoEgg;
+import jp.minecraftuser.ecoframework.PluginFrame;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 
+/**
+ * YAML読み込みクラス
+ * @author ecolight
+ */
 public class LoaderYaml {
-    private EcoEgg plg = null;
+    private PluginFrame plg = null;
     private String filename = null;
-    
+    protected Logger log = null;
+
     private FileConfiguration cnf = null;
     private File cnfFile = null;
-    
-    public LoaderYaml(EcoEgg plg, String filename) {
-        this.plg = plg;
-        this.filename = filename;
+
+    /**
+     * コンストラクタ
+     * @param plg_
+     * @param filename_
+     */
+    public LoaderYaml(PluginFrame plg_, String filename_) {
+        plg = plg_;
+        filename = filename_;
+        log = plg.getLogger();
     }
+
+    /**
+     * コンフィグ再読み込み
+     */
     public void reloadCnf() {
+        // 無ければ新規作成する
         if (cnfFile == null) {
             cnfFile = new File(plg.getDataFolder(), this.filename);
         }
+        // 現在の内容を読み込み
         cnf = YamlConfiguration.loadConfiguration(cnfFile);
 
-        try {
-            Reader def = new InputStreamReader(plg.getResource(filename), "UTF8") ;
-            YamlConfiguration defConfig = YamlConfiguration.loadConfiguration(def);
+        // JARファイル内の初期値ファイルに書かれている値を取得してデフォルト値にする
+        InputStream defCnfStream = plg.getResource(this.filename);
+        if (defCnfStream != null) {
+            YamlConfiguration defConfig = YamlConfiguration.loadConfiguration(new InputStreamReader(defCnfStream, StandardCharsets.UTF_8));
             cnf.setDefaults(defConfig);
-        } catch (UnsupportedEncodingException ex) {
-            Logger.getLogger(LoaderYaml.class.getName()).log(Level.SEVERE, null, ex);
         }
     }
 
+    /**
+     * 直接操作用にコンフィグインスタンスを取得する
+     * @return コンフィグファイルインスタンス
+     */
     public FileConfiguration getCnf() {
+        /**
+         * まだ未ロードであれば読み込んでから返す
+         */
         if (cnf == null) {
             this.reloadCnf();
         }
         return cnf;
     }
 
+    /**
+     * セーブする
+     */
     public void saveCnf() {
-        if (cnf == null || cnfFile == null) {
-        return;
-        }
+        // まだ読み込みされていない場合には何もしない
+        // R->Wが前提のため読み込みされていない状態はまだ保存すべき状態でないと断定する
+        if (cnf == null || cnfFile == null) return;
         try {
-            getCnf().save(cnfFile);
+            cnf.save(cnfFile);
         } catch (IOException ex) {
-            plg.getLogger().log(Level.SEVERE, "Could not save config to " + cnfFile, ex);
+            plg.getLogger().log(Level.SEVERE, "failed save configuration file. file=" + cnfFile, ex);
         }
     }
 }

--- a/src/main/java/jp/minecraftuser/ecoegg/listener/PlayerListener.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/listener/PlayerListener.java
@@ -1,9 +1,11 @@
 
 package jp.minecraftuser.ecoegg.listener;
 
+import java.lang.reflect.Method;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.UUID;
+
 import jp.minecraftuser.ecoegg.EcoEgg;
 import jp.minecraftuser.ecoegg.InfoParam;
 import jp.minecraftuser.ecoframework.PluginFrame;
@@ -17,15 +19,7 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.block.Block;
-import org.bukkit.entity.Creeper;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
-import org.bukkit.entity.Horse;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Ocelot;
-import org.bukkit.entity.Player;
-import org.bukkit.entity.Rabbit;
-import org.bukkit.entity.Wolf;
+import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.entity.EntityDamageEvent;
@@ -40,23 +34,27 @@ import org.bukkit.material.MaterialData;
 
 /**
  * プレイヤー系イベントリスナクラス
+ *
  * @author ecolight
  */
-public class PlayerListener extends ListenerFrame  {
+public class PlayerListener extends ListenerFrame {
     private static EcoEggConfig eceConf = null;
+
     /**
      * コンストラクタ
-     * @param plg_ プラグインインスタンス
+     *
+     * @param plg_  プラグインインスタンス
      * @param name_ 名前
      */
     public PlayerListener(PluginFrame plg_, String name_) {
         super(plg_, name_);
-        eceConf = (EcoEggConfig)conf;
+        eceConf = (EcoEggConfig) conf;
     }
-    
+
     /**
      * プレイヤーエンティティ作用イベント
-     * @param event 
+     *
+     * @param event
      */
     @EventHandler(priority = EventPriority.LOWEST)
     public void PlayerInteractEntity(PlayerInteractEntityEvent event) {
@@ -67,7 +65,7 @@ public class PlayerListener extends ListenerFrame  {
         Player pl = event.getPlayer();
         Entity ent = event.getRightClicked();
 
-        if (((EcoEgg)plg).chkInfoUser(pl)) {
+        if (((EcoEgg) plg).chkInfoUser(pl)) {
             switch (ent.getType()) {
                 case HORSE:
                 case OCELOT:
@@ -77,63 +75,63 @@ public class PlayerListener extends ListenerFrame  {
                     pl.sendMessage(m.plg("infoコマンドの対象外のエンティティです"));
                     return;
             }
-            
+
             // MOB個別処理
             InfoParam param;
             switch (ent.getType()) {
                 case HORSE:
                     Horse horse = (Horse) ent;
-                    param = ((EcoEgg)plg).getParamUser(pl);
+                    param = ((EcoEgg) plg).getParamUser(pl);
 
                     // 馬ステータス表示
                     pl.sendMessage(m.plg("===== 馬ステータス表示 ====="));
-                    if (horse.getCustomName() != null) pl.sendMessage(m.plg("Name:"+horse.getCustomName()));
-                    pl.sendMessage(m.plg("MaxHealth:"+horse.getAttribute(Attribute.GENERIC_MAX_HEALTH).getBaseValue()));
-                    pl.sendMessage(m.plg("Health:"+horse.getHealth()));
-                    if (horse.getOwner() != null) pl.sendMessage(m.plg("Owner:"+horse.getOwner().getName()));
-                    pl.sendMessage(m.plg("MaxDomestication:"+horse.getMaxDomestication()));
-                    pl.sendMessage(m.plg("Domestication:"+horse.getDomestication()));
-                    pl.sendMessage(m.plg("Age:"+horse.getAge()));
-                    pl.sendMessage(m.plg("Style:"+horse.getStyle().name()));
-                    pl.sendMessage(m.plg("Color:"+horse.getColor().name()));
-                    pl.sendMessage(m.plg("Variant:"+horse.getVariant().name()));
-                    pl.sendMessage(m.plg("JumpStrength:"+horse.getAttribute(Attribute.HORSE_JUMP_STRENGTH).getBaseValue()));
-                    pl.sendMessage(m.plg("Speed:"+horse.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED).getBaseValue()));
+                    if (horse.getCustomName() != null) pl.sendMessage(m.plg("Name:" + horse.getCustomName()));
+                    pl.sendMessage(m.plg("MaxHealth:" + horse.getAttribute(Attribute.GENERIC_MAX_HEALTH).getBaseValue()));
+                    pl.sendMessage(m.plg("Health:" + horse.getHealth()));
+                    if (horse.getOwner() != null) pl.sendMessage(m.plg("Owner:" + horse.getOwner().getName()));
+                    pl.sendMessage(m.plg("MaxDomestication:" + horse.getMaxDomestication()));
+                    pl.sendMessage(m.plg("Domestication:" + horse.getDomestication()));
+                    pl.sendMessage(m.plg("Age:" + horse.getAge()));
+                    pl.sendMessage(m.plg("Style:" + horse.getStyle().name()));
+                    pl.sendMessage(m.plg("Color:" + horse.getColor().name()));
+                    pl.sendMessage(m.plg("Variant:" + horse.getVariant().name()));
+                    pl.sendMessage(m.plg("JumpStrength:" + horse.getAttribute(Attribute.HORSE_JUMP_STRENGTH).getBaseValue()));
+                    pl.sendMessage(m.plg("Speed:" + horse.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED).getBaseValue()));
                     pl.sendMessage(m.plg("===== 馬ステータスここまで ====="));
                     break;
                 case OCELOT:
                     Ocelot cat = (Ocelot) ent;
-                    param = ((EcoEgg)plg).getParamUser(pl);
+                    param = ((EcoEgg) plg).getParamUser(pl);
 
                     // 猫ステータス表示
                     pl.sendMessage(m.plg("===== 猫ステータス表示 ====="));
-                    if (cat.getCustomName() != null) pl.sendMessage(m.plg("Name:"+cat.getCustomName()));
-                    pl.sendMessage(m.plg("MaxHealth:"+cat.getMaxHealth()));
-                    pl.sendMessage(m.plg("Health:"+cat.getHealth()));
-                    if (cat.getOwner() != null) pl.sendMessage(m.plg("Owner:"+cat.getOwner().getName()));
-                    pl.sendMessage(m.plg("Age:"+cat.getAge()));
-                    pl.sendMessage(m.plg("CatType:"+cat.getCatType().name()));
+                    if (cat.getCustomName() != null) pl.sendMessage(m.plg("Name:" + cat.getCustomName()));
+                    pl.sendMessage(m.plg("MaxHealth:" + cat.getMaxHealth()));
+                    pl.sendMessage(m.plg("Health:" + cat.getHealth()));
+                    if (cat.getOwner() != null) pl.sendMessage(m.plg("Owner:" + cat.getOwner().getName()));
+                    pl.sendMessage(m.plg("Age:" + cat.getAge()));
+                    pl.sendMessage(m.plg("CatType:" + cat.getCatType().name()));
                     pl.sendMessage(m.plg("===== 猫ステータスここまで ====="));
                     break;
                 case WOLF:
                     Wolf dog = (Wolf) ent;
-                    param = ((EcoEgg)plg).getParamUser(pl);
+                    param = ((EcoEgg) plg).getParamUser(pl);
 
                     // 猫ステータス表示
                     pl.sendMessage(m.plg("===== 犬ステータス表示 ====="));
-                    if (dog.getCustomName() != null) pl.sendMessage(m.plg("Name:"+dog.getCustomName()));
-                    pl.sendMessage(m.plg("MaxHealth:"+dog.getMaxHealth()));
-                    pl.sendMessage(m.plg("Health:"+dog.getHealth()));
-                    if (dog.getOwner() != null) pl.sendMessage(m.plg("Owner:"+dog.getOwner().getName()));
-                    pl.sendMessage(m.plg("Age:"+dog.getAge()));
-                    pl.sendMessage(m.plg("Color:"+dog.getCollarColor().name()));
+                    if (dog.getCustomName() != null) pl.sendMessage(m.plg("Name:" + dog.getCustomName()));
+                    pl.sendMessage(m.plg("MaxHealth:" + dog.getMaxHealth()));
+                    pl.sendMessage(m.plg("Health:" + dog.getHealth()));
+                    if (dog.getOwner() != null) pl.sendMessage(m.plg("Owner:" + dog.getOwner().getName()));
+                    pl.sendMessage(m.plg("Age:" + dog.getAge()));
+                    pl.sendMessage(m.plg("Color:" + dog.getCollarColor().name()));
                     pl.sendMessage(m.plg("===== 犬ステータスここまで ====="));
                     break;
             }
-            
+
             event.setCancelled(true);
             return;
-        } else if (((EcoEgg)plg).chkSetUser(pl)) {
+        } else if (((EcoEgg) plg).chkSetUser(pl)) {
             switch (ent.getType()) {
                 case HORSE:
                     break;
@@ -145,99 +143,161 @@ public class PlayerListener extends ListenerFrame  {
             switch (ent.getType()) {
                 case HORSE:
                     Horse horse = (Horse) ent;
-                    param = ((EcoEgg)plg).getParamUser(pl);
+                    param = ((EcoEgg) plg).getParamUser(pl);
                     switch (param.getOpt()) {
                         case JUMP:
                             horse.setJumpStrength(param.getVal());
-                            pl.sendMessage(m.plg("ジャンプ力[")+horse.getJumpStrength()+"]を設定しました");
+                            pl.sendMessage(m.plg("ジャンプ力[") + horse.getJumpStrength() + "]を設定しました");
                             break;
                         case SPEED:
                             horse.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED).setBaseValue(param.getVal());
-                            pl.sendMessage(m.plg("スピード[")+horse.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED).getBaseValue() +"]を設定しました");
+                            pl.sendMessage(m.plg("スピード[") + horse.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED).getBaseValue() + "]を設定しました");
                             break;
                         case HEALTH:
                             horse.setMaxHealth(param.getVal());
-                            pl.sendMessage(m.plg("HP最大値[")+horse.getMaxHealth()+"]を設定しました");
+                            pl.sendMessage(m.plg("HP最大値[") + horse.getMaxHealth() + "]を設定しました");
                             break;
                         case OWNER:
                             if (plg.getServer().getPlayerExact(param.getStr()) == null) return;
                             horse.setOwner(plg.getServer().getPlayerExact(param.getStr()));
-                            pl.sendMessage(m.plg("飼い主[")+horse.getOwner().getName()+"]を設定しました");
+                            pl.sendMessage(m.plg("飼い主[") + horse.getOwner().getName() + "]を設定しました");
                             break;
                         case STYLE:
                             horse.setStyle(param.getHorseStyle());
-                            pl.sendMessage(m.plg("スタイル[")+horse.getStyle().name()+"]を設定しました");
+                            pl.sendMessage(m.plg("スタイル[") + horse.getStyle().name() + "]を設定しました");
                             break;
                         case COLOR:
                             horse.setColor(param.getHorseColor());
-                            pl.sendMessage(m.plg("色[")+horse.getColor().name()+"]を設定しました");
+                            pl.sendMessage(m.plg("色[") + horse.getColor().name() + "]を設定しました");
                             break;
                         case VARIANT:
                             horse.setVariant(param.getHorseVariant());
-                            pl.sendMessage(m.plg("Variant[")+horse.getVariant().name()+"]を設定しました");
+                            pl.sendMessage(m.plg("Variant[") + horse.getVariant().name() + "]を設定しました");
                             break;
                     }
                     break;
             }
-            
+
             event.setCancelled(true);
             return;
         }
-        
-        
+
+
         String dispname = "";
         byte mobnum = 0;
-        switch(ent.getType()) {
+        //モンスターエッグに変換できない場合はキャンセル
+        if (!existMonsterEgg(ent)) {
+            return;
+        }
+        switch (ent.getType()) {
             case EGG:
                 event.getPlayer().sendMessage("egg");
                 return;
-            case BAT: mobnum = 65; break;
-            case BLAZE: mobnum = 61; break;
-            case CAVE_SPIDER: mobnum = 59; break;
-            case CHICKEN: mobnum = 93; break;
-            case COW: mobnum = 92; break;
-            case CREEPER: mobnum = 50; break;
-            case ENDERMAN: mobnum = 58; break;
-            case GHAST: mobnum = 56; break;
-            case MAGMA_CUBE: mobnum = 62; break;
-            case MUSHROOM_COW: mobnum = 96; break;
-            case OCELOT: mobnum = 98; break;
-            case PIG: mobnum = 90; break;
-            case PIG_ZOMBIE: mobnum = 57; break;
-            case SHEEP: mobnum = 91; break;
-            case SILVERFISH: mobnum = 60; break;
-            case SKELETON: mobnum = 51; break;
-            case SLIME: mobnum = 55; break;
-            case SPIDER: mobnum = 52; break;
-            case SQUID: mobnum = 94; break;
-            case VILLAGER: mobnum = 120; break;
-            case WITCH: mobnum = 66; break;
-            case WOLF: mobnum = 95; break;
-            case ZOMBIE: mobnum = 54; break;
-            case HORSE: mobnum = 100; break;
-            case RABBIT: mobnum = 101; break;
-            case GUARDIAN: mobnum = 68; break;
-            case ENDERMITE: mobnum = 67; break;
+            case BAT:
+                mobnum = 65;
+                break;
+            case BLAZE:
+                mobnum = 61;
+                break;
+            case CAVE_SPIDER:
+                mobnum = 59;
+                break;
+            case CHICKEN:
+                mobnum = 93;
+                break;
+            case COW:
+                mobnum = 92;
+                break;
+            case CREEPER:
+                mobnum = 50;
+                break;
+            case ENDERMAN:
+                mobnum = 58;
+                break;
+            case GHAST:
+                mobnum = 56;
+                break;
+            case MAGMA_CUBE:
+                mobnum = 62;
+                break;
+            case MUSHROOM_COW:
+                mobnum = 96;
+                break;
+            case OCELOT:
+                mobnum = 98;
+                break;
+            case PIG:
+                mobnum = 90;
+                break;
+            case PIG_ZOMBIE:
+                mobnum = 57;
+                break;
+            case SHEEP:
+                mobnum = 91;
+                break;
+            case SILVERFISH:
+                mobnum = 60;
+                break;
+            case SKELETON:
+                mobnum = 51;
+                break;
+            case SLIME:
+                mobnum = 55;
+                break;
+            case SPIDER:
+                mobnum = 52;
+                break;
+            case SQUID:
+                mobnum = 94;
+                break;
+            case VILLAGER:
+                mobnum = 120;
+                break;
+            case WITCH:
+                mobnum = 66;
+                break;
+            case WOLF:
+                mobnum = 95;
+                break;
+            case ZOMBIE:
+                mobnum = 54;
+                break;
+            case HORSE:
+                mobnum = 100;
+                break;
+            case RABBIT:
+                mobnum = 101;
+                break;
+            case GUARDIAN:
+                mobnum = 68;
+                break;
+            case ENDERMITE:
+                mobnum = 67;
+                break;
             default:
-                return;
+                //上の条件に当てはまなければ-1
+                mobnum = -1;
+                break;
+            //return;
         }
-        
+
+
         //----------------------------------------------------------------------
         // プレイヤーの持っている物が魔道書か
         //----------------------------------------------------------------------
         boolean bookcheck = true;
-        if (((EcoEgg)plg).getGetter() != null) {
-            if (((EcoEgg)plg).getGetter().equals(pl)) {
+        if (((EcoEgg) plg).getGetter() != null) {
+            if (((EcoEgg) plg).getGetter().equals(pl)) {
                 // 魔道書判定スキップ、初期化
                 bookcheck = false;
-                ((EcoEgg)plg).setGetter(null);
+                ((EcoEgg) plg).setGetter(null);
             }
         }
         if (bookcheck) {
             ItemStack is = pl.getItemInHand();
             if (is.getType() != Material.WRITTEN_BOOK) return;
             // 魔道書の記述が正しいか
-            BookMeta meta = (BookMeta)pl.getItemInHand().getItemMeta();
+            BookMeta meta = (BookMeta) pl.getItemInHand().getItemMeta();
 
             if (!meta.getAuthor().equals(eceConf.getAuthor())) return;
             if (!meta.getTitle().equals(eceConf.getTitle())) return;
@@ -247,23 +307,23 @@ public class PlayerListener extends ListenerFrame  {
         //----------------------------------------------------------------------
         // 他者のMOBの場合は魔道書のみ消滅
         //----------------------------------------------------------------------
-        LivingEntity le = (LivingEntity)ent;
+        LivingEntity le = (LivingEntity) ent;
         Location loc = le.getLocation();
         boolean reject = false;
         switch (le.getType()) {
             case WOLF:
-                if (((Wolf)le).getOwner() == null) break;
-                if (((Wolf)le).getOwner().getName().equals(pl.getName())) break;
+                if (((Wolf) le).getOwner() == null) break;
+                if (((Wolf) le).getOwner().getName().equals(pl.getName())) break;
                 reject = true;
                 break;
             case OCELOT:
-                if (((Ocelot)le).getOwner() == null) break;
-                if (((Ocelot)le).getOwner().getName().equals(pl.getName())) break;
+                if (((Ocelot) le).getOwner() == null) break;
+                if (((Ocelot) le).getOwner().getName().equals(pl.getName())) break;
                 reject = true;
                 break;
             case HORSE:
-                if (((Horse)le).getOwner() == null) break;
-                if (((Horse)le).getOwner().getName().equals(pl.getName())) break;
+                if (((Horse) le).getOwner() == null) break;
+                if (((Horse) le).getOwner().getName().equals(pl.getName())) break;
                 reject = true;
                 break;
         }
@@ -276,7 +336,7 @@ public class PlayerListener extends ListenerFrame  {
                 } else {
                     is.setAmount(is.getAmount() - 1);
                     pl.setItemInHand(is);
-                } 
+                }
             }
             loc.getWorld().strikeLightningEffect(loc);
             return;
@@ -285,35 +345,39 @@ public class PlayerListener extends ListenerFrame  {
         //----------------------------------------------------------------------
         // MOBたまご生成
         //----------------------------------------------------------------------
-        ItemStack egg = new ItemStack(Material.MONSTER_EGG);
+        ItemStack egg = new ItemStack(Material.PIG_SPAWN_EGG);
         ItemMeta em = egg.getItemMeta();
-        
+
         MaterialData md = egg.getData();
         md.setData(mobnum);
         egg.setData(md);
         egg.setDurability(mobnum);
         LoaderMob save = new LoaderMob((EcoEgg) plg, le.getUniqueId());
         save.setUsed(false);
-        le.getType().name();
-
         save.setMobType(le.getType().getTypeId());
         save.setCustomName(le.getCustomName());
         save.setMaxHealth(le.getMaxHealth());
         save.setHealth(le.getHealth());
 
         // MOB情報収集
-        switch(le.getType()) {
+        switch (le.getType()) {
             case HORSE:
-                Horse horse = (Horse)le;
+                Horse horse = (Horse) le;
                 // 装備とインベントリ内アイテムドロップ
-                for (ItemStack i: horse.getEquipment().getArmorContents()) {
+                for (ItemStack i : horse.getEquipment().getArmorContents()) {
                     if (i.getType() == Material.AIR) continue;
                     le.getWorld().dropItem(loc, i);
                 }
-                for (ItemStack i: horse.getInventory().getContents()) {
-                    if (i == null) {m.info("i null"); continue;}
+                for (ItemStack i : horse.getInventory().getContents()) {
+                    if (i == null) {
+                        m.info("i null");
+                        continue;
+                    }
                     if (i.getType() == Material.AIR) continue;
-                    if (loc == null) {m.info("loc null"); return;}
+                    if (loc == null) {
+                        m.info("loc null");
+                        return;
+                    }
                     le.getWorld().dropItem(loc, i);
                 }
                 save.setMaxDomestication(horse.getMaxDomestication());
@@ -329,7 +393,7 @@ public class PlayerListener extends ListenerFrame  {
                 save.setChild(!horse.isAdult());
                 break;
             case WOLF:
-                Wolf wolf = (Wolf)le;
+                Wolf wolf = (Wolf) le;
                 save.setAge(wolf.getAge());
                 save.setCollar(wolf.getCollarColor());
                 save.setBleed(wolf.canBreed());
@@ -338,7 +402,7 @@ public class PlayerListener extends ListenerFrame  {
                 if (wolf.getOwner() != null) save.setOwner(wolf.getOwner().getName());
                 break;
             case OCELOT:
-                Ocelot ocelot = (Ocelot)le;
+                Ocelot ocelot = (Ocelot) le;
                 save.setAge(ocelot.getAge());
                 save.setCatType(ocelot.getCatType());
                 save.setBleed(ocelot.canBreed());
@@ -346,11 +410,11 @@ public class PlayerListener extends ListenerFrame  {
                 if (ocelot.getOwner() != null) save.setOwner(ocelot.getOwner().getName());
                 break;
             case CREEPER:
-                Creeper creeper = (Creeper)le;
+                Creeper creeper = (Creeper) le;
                 save.setPower(creeper.isPowered());
                 break;
             case RABBIT:
-                Rabbit rabbit = (Rabbit)le;
+                Rabbit rabbit = (Rabbit) le;
                 save.setRabbitType(rabbit.getRabbitType());
                 save.setBleed(rabbit.canBreed());
                 save.setAge(rabbit.getAge());
@@ -363,11 +427,11 @@ public class PlayerListener extends ListenerFrame  {
 //        if (name != null) {
 //            im.setDisplayName("[EcoEgg]("+name+"),"+le.getUniqueId().getMostSignificantBits()+","+le.getUniqueId().getLeastSignificantBits());
 //        } else {
-            im.setDisplayName("[EcoEgg],"+le.getUniqueId().getMostSignificantBits()+","+le.getUniqueId().getLeastSignificantBits());
+        im.setDisplayName("[EcoEgg]," + le.getUniqueId().getMostSignificantBits() + "," + le.getUniqueId().getLeastSignificantBits());
 //        }
         egg.setItemMeta(im);
 
-        
+
         ItemStack is = pl.getItemInHand();
         if (is.getAmount() == 1) {
             pl.getInventory().setItemInMainHand(egg);
@@ -380,10 +444,10 @@ public class PlayerListener extends ListenerFrame  {
                 if (i == null) {
                     break;
                 }
-                ii++; 
+                ii++;
             }
             if (ii == in.getSize()) {
-                pl.sendMessage(ChatColor.AQUA+"[EcoEgg] インベントリに空きが無いので使用できません");
+                pl.sendMessage(ChatColor.AQUA + "[EcoEgg] インベントリに空きが無いので使用できません");
                 event.setCancelled(true);
                 return;
             } else {
@@ -392,21 +456,22 @@ public class PlayerListener extends ListenerFrame  {
                 in.setItem(ii, egg);
                 pl.getInventory().getItem(ii).setAmount(1);
             }
-        } 
+        }
         Date date = new Date();
         SimpleDateFormat sdf1 = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
         save.saveGen(pl.getName(), ent.getType().name(), sdf1.format(date));
         save.saveDate(date.getTime());
         le.remove();
         pl.getWorld().strikeLightningEffect(loc);
-        pl.sendMessage(ChatColor.AQUA+"[EcoEgg] MOBをたまごに変換しました");
-        m.info("ChangeMobEgg["+pl.getName()+"]"+pl.getLocation().toString()+",MOB:"+mobnum);
+        pl.sendMessage(ChatColor.AQUA + "[EcoEgg] MOBをたまごに変換しました");
+        m.info("ChangeMobEgg[" + pl.getName() + "]" + pl.getLocation().toString() + ",MOB:" + mobnum);
         event.setCancelled(true);
     }
 
     /**
      * プレイヤー作用イベントハンドラ
-     * @param event 
+     *
+     * @param event
      */
     @EventHandler(priority = EventPriority.LOWEST)
     public void PlayerInteract(PlayerInteractEvent event) {
@@ -417,8 +482,12 @@ public class PlayerListener extends ListenerFrame  {
         if (i == null) return;
 
         // モンスターエッグ以外は処理しない
-        if (i.getType() != Material.MONSTER_EGG) return;
-        
+
+        if (!isMonsterEgg(i)) {
+            return;
+        }
+
+
         // メタ取得
         ItemMeta meta = i.getItemMeta();
         if (meta == null) return;
@@ -430,59 +499,118 @@ public class PlayerListener extends ListenerFrame  {
         String[] token = itemname.split(",");
         String most = token[token.length - 2];
         String least = token[token.length - 1];
-        
+
         // MOBのyaml情報を取得
         LoaderMob load = new LoaderMob((EcoEgg) plg, new UUID(Long.parseLong(most), Long.parseLong(least)));
-        
+
         // 使用済みなら不正アイテム、ただしOPは問題なし
         if (load.getUsed() && (!event.getPlayer().isOp())) {
-            m.info("使用済みたまご利用:"+most+","+least+"["+event.getPlayer().getName()+"]");
-            event.getPlayer().sendMessage(m.plg("管理者に通報されました：使用済みたまご利用:"+most+","+least+"["+event.getPlayer().getName()+"]"));
+            m.info("使用済みたまご利用:" + most + "," + least + "[" + event.getPlayer().getName() + "]");
+            event.getPlayer().sendMessage(m.plg("管理者に通報されました：使用済みたまご利用:" + most + "," + least + "[" + event.getPlayer().getName() + "]"));
             event.setCancelled(true);
             return;
         }
-        
+
         // インターバルの監視
         Date date = new Date();
         if (date.getTime() < load.getDate() + 1000 * 30) {
-            event.getPlayer().sendMessage(m.plg("再使用まであと "+(30-(date.getTime()-load.getDate())/1000)+" 秒必要です"));
+            event.getPlayer().sendMessage(m.plg("再使用まであと " + (30 - (date.getTime() - load.getDate()) / 1000) + " 秒必要です"));
             event.setCancelled(true);
             return;
         }
-        
+
         EntityType type;
-        switch(load.getMobType()) {
-            case 65: type = EntityType.BAT; break;
-            case 61: type = EntityType.BLAZE; break;
-            case 59: type = EntityType.CAVE_SPIDER; break;
-            case 93: type = EntityType.CHICKEN; break;
-            case 92: type = EntityType.COW; break;
-            case 50: type = EntityType.CREEPER; break;
-            case 58: type = EntityType.ENDERMAN; break;
-            case 56: type = EntityType.GHAST; break;
-            case 62: type = EntityType.MAGMA_CUBE; break;
-            case 96: type = EntityType.MUSHROOM_COW; break;
-            case 98: type = EntityType.OCELOT; break;
-            case 90: type = EntityType.PIG; break;
-            case 57: type = EntityType.PIG_ZOMBIE; break;
-            case 91: type = EntityType.SHEEP; break;
-            case 60: type = EntityType.SILVERFISH; break;
-            case 51: type = EntityType.SKELETON; break;
-            case 55: type = EntityType.SLIME; break;
-            case 52: type = EntityType.SPIDER; break;
-            case 94: type = EntityType.SQUID; break;
-            case 120: type = EntityType.VILLAGER; break;
-            case 66: type = EntityType.WITCH; break;
-            case 95: type = EntityType.WOLF; break;
-            case 54: type = EntityType.ZOMBIE; break;
-            case 100: type = EntityType.HORSE; break;
-            case 101: type = EntityType.RABBIT; break;
-            case 68: type = EntityType.GUARDIAN; break;
-            case 67: type = EntityType.ENDERMITE; break;
-            default:
-                return;
+        //もし-MobTypeが-1ならgen_typeからモンスター名を取ってくる
+        if (load.getMobType() != -1) {
+            switch (load.getMobType()) {
+                case 65:
+                    type = EntityType.BAT;
+                    break;
+                case 61:
+                    type = EntityType.BLAZE;
+                    break;
+                case 59:
+                    type = EntityType.CAVE_SPIDER;
+                    break;
+                case 93:
+                    type = EntityType.CHICKEN;
+                    break;
+                case 92:
+                    type = EntityType.COW;
+                    break;
+                case 50:
+                    type = EntityType.CREEPER;
+                    break;
+                case 58:
+                    type = EntityType.ENDERMAN;
+                    break;
+                case 56:
+                    type = EntityType.GHAST;
+                    break;
+                case 62:
+                    type = EntityType.MAGMA_CUBE;
+                    break;
+                case 96:
+                    type = EntityType.MUSHROOM_COW;
+                    break;
+                case 98:
+                    type = EntityType.OCELOT;
+                    break;
+                case 90:
+                    type = EntityType.PIG;
+                    break;
+                case 57:
+                    type = EntityType.PIG_ZOMBIE;
+                    break;
+                case 91:
+                    type = EntityType.SHEEP;
+                    break;
+                case 60:
+                    type = EntityType.SILVERFISH;
+                    break;
+                case 51:
+                    type = EntityType.SKELETON;
+                    break;
+                case 55:
+                    type = EntityType.SLIME;
+                    break;
+                case 52:
+                    type = EntityType.SPIDER;
+                    break;
+                case 94:
+                    type = EntityType.SQUID;
+                    break;
+                case 120:
+                    type = EntityType.VILLAGER;
+                    break;
+                case 66:
+                    type = EntityType.WITCH;
+                    break;
+                case 95:
+                    type = EntityType.WOLF;
+                    break;
+                case 54:
+                    type = EntityType.ZOMBIE;
+                    break;
+                case 100:
+                    type = EntityType.HORSE;
+                    break;
+                case 101:
+                    type = EntityType.RABBIT;
+                    break;
+                case 68:
+                    type = EntityType.GUARDIAN;
+                    break;
+                case 67:
+                    type = EntityType.ENDERMITE;
+                    break;
+                default:
+                    return;
+            }
+        } else {
+            type = EntityType.valueOf(load.getGenType());
         }
-        
+
         // 一応本のクリック判定をキャンセル？
         boolean ownerreset = false;
         Block b = event.getClickedBlock();
@@ -490,13 +618,13 @@ public class PlayerListener extends ListenerFrame  {
             event.setCancelled(true);
             return;
         }
-        
+
         // MOBスポーン処理
         Location loc = b.getLocation();
-        loc.setY(loc.getY()+2);        
+        loc.setY(loc.getY() + 2);
         Player pl = event.getPlayer();
         LivingEntity ent = (LivingEntity) b.getWorld().spawnEntity(loc, type);
-        
+
         // MOBスポーン後のMOB共通処理
         load.setUsed(true);
         ent.setMaxHealth(load.getMaxHealth());
@@ -504,7 +632,7 @@ public class PlayerListener extends ListenerFrame  {
         String name = load.getCustomName();
         if (name != null) ent.setCustomName(name);
         String owner = load.getOwner();
-        
+
         // MOBスポーン後のMOB個別処理
         switch (type) {
             // 犬用
@@ -518,7 +646,7 @@ public class PlayerListener extends ListenerFrame  {
                 } else {
                     wolf.setAdult();
                 }
-                if (b.getType() == Material.MELON_BLOCK) ownerreset = true;
+                if (b.getType() == Material.LEGACY_MELON_BLOCK) ownerreset = true;
                 if (ownerreset) {
                     if (owner != null) wolf.setOwner(pl);
                 } else {
@@ -535,7 +663,7 @@ public class PlayerListener extends ListenerFrame  {
                 } else {
                     ocelot.setAdult();
                 }
-                if (b.getType() == Material.CAKE_BLOCK) ownerreset = true;
+                if (b.getType() == Material.LEGACY_CAKE_BLOCK) ownerreset = true;
                 if (ownerreset) {
                     if (owner != null) ocelot.setOwner(pl);
                 } else {
@@ -584,14 +712,15 @@ public class PlayerListener extends ListenerFrame  {
         }
         SimpleDateFormat sdf1 = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
         load.saveUse(pl.getName(), ent.getType().name(), sdf1.format(date));
-        
+
         event.setCancelled(true);
         if (pl.getGameMode() != GameMode.CREATIVE) pl.setItemInHand(new ItemStack(Material.AIR));
     }
 
     /**
      * エコエッグ本生成
-     * @param event 
+     *
+     * @param event
      */
     @EventHandler(priority = EventPriority.LOWEST)
     public void PrepareItemCraft(PrepareItemCraftEvent event) {
@@ -599,7 +728,7 @@ public class PlayerListener extends ListenerFrame  {
         //plg.getServer().broadcastMessage("is:"+is.toString());
         if (is.getType() != Material.WRITTEN_BOOK) return;
         // 魔道書の記述が正しいか
-        BookMeta meta = (BookMeta)is.getItemMeta();
+        BookMeta meta = (BookMeta) is.getItemMeta();
         if (meta == null) return;
         if (!meta.getAuthor().equals(eceConf.getAuthor())) return;
         if (!meta.getTitle().equals(eceConf.getTitle())) return;
@@ -611,7 +740,8 @@ public class PlayerListener extends ListenerFrame  {
 
     /**
      * エンティティダメージイベントハンドラ
-     * @param event 
+     *
+     * @param event
      */
     @EventHandler(priority = EventPriority.LOWEST)
     public void EntityDamage(EntityDamageEvent event) {
@@ -625,8 +755,9 @@ public class PlayerListener extends ListenerFrame  {
      * MOB落下ダメージ判定
      * OPの乗り物にはダメージ入れない
      * 後でプロパティ化する
+     *
      * @param event
-     * @return 
+     * @return
      */
     private boolean isFallingDamageCanceled(EntityDamageEvent event) {
         if (event.getCause() != EntityDamageEvent.DamageCause.FALL) return false;
@@ -639,4 +770,123 @@ public class PlayerListener extends ListenerFrame  {
         if (!pl.isOp()) return false;
         return true;
     }
+
+    public boolean existMonsterEgg(Entity e) {
+        switch (e.getType()) {
+            case ELDER_GUARDIAN:
+            case WITHER_SKELETON:
+            case STRAY:
+            case HUSK:
+            case ZOMBIE_VILLAGER:
+            case SKELETON_HORSE:
+            case ZOMBIE_HORSE:
+            case DONKEY:
+            case MULE:
+            case EVOKER:
+            case VEX:
+            case VINDICATOR:
+            case CREEPER:
+            case SKELETON:
+            case SPIDER:
+            case ZOMBIE:
+            case SLIME:
+            case GHAST:
+            case PIG_ZOMBIE:
+            case ENDERMAN:
+            case CAVE_SPIDER:
+            case SILVERFISH:
+            case BLAZE:
+            case MAGMA_CUBE:
+            case BAT:
+            case WITCH:
+            case ENDERMITE:
+            case GUARDIAN:
+            case SHULKER:
+            case PIG:
+            case SHEEP:
+            case COW:
+            case CHICKEN:
+            case SQUID:
+            case WOLF:
+                //mooshroom?
+            case OCELOT:
+            case HORSE:
+            case RABBIT:
+            case POLAR_BEAR:
+            case LLAMA:
+            case PARROT:
+            case VILLAGER:
+            case COD:
+            case DOLPHIN:
+            case DROWNED:
+            case PHANTOM:
+            case PUFFERFISH:
+            case SALMON:
+            case TROPICAL_FISH:
+            case TURTLE:
+                return true;
+
+        }
+        return false;
+    }
+
+    public boolean isMonsterEgg(ItemStack item) {
+        switch (item.getType()) {
+            case ELDER_GUARDIAN_SPAWN_EGG:
+            case WITHER_SKELETON_SPAWN_EGG:
+            case STRAY_SPAWN_EGG:
+            case HUSK_SPAWN_EGG:
+            case ZOMBIE_VILLAGER_SPAWN_EGG:
+            case SKELETON_HORSE_SPAWN_EGG:
+            case ZOMBIE_HORSE_SPAWN_EGG:
+            case DONKEY_SPAWN_EGG:
+            case MULE_SPAWN_EGG:
+            case EVOKER_SPAWN_EGG:
+            case VEX_SPAWN_EGG:
+            case VINDICATOR_SPAWN_EGG:
+            case CREEPER_SPAWN_EGG:
+            case SKELETON_SPAWN_EGG:
+            case SPIDER_SPAWN_EGG:
+            case ZOMBIE_SPAWN_EGG:
+            case SLIME_SPAWN_EGG:
+            case GHAST_SPAWN_EGG:
+            case ZOMBIE_PIGMAN_SPAWN_EGG:
+            case ENDERMAN_SPAWN_EGG:
+            case CAVE_SPIDER_SPAWN_EGG:
+            case SILVERFISH_SPAWN_EGG:
+            case BLAZE_SPAWN_EGG:
+            case MAGMA_CUBE_SPAWN_EGG:
+            case BAT_SPAWN_EGG:
+            case WITCH_SPAWN_EGG:
+            case ENDERMITE_SPAWN_EGG:
+            case GUARDIAN_SPAWN_EGG:
+            case SHULKER_SPAWN_EGG:
+            case PIG_SPAWN_EGG:
+            case SHEEP_SPAWN_EGG:
+            case COW_SPAWN_EGG:
+            case CHICKEN_SPAWN_EGG:
+            case SQUID_SPAWN_EGG:
+            case WOLF_SPAWN_EGG:
+            case MOOSHROOM_SPAWN_EGG:
+            case OCELOT_SPAWN_EGG:
+            case HORSE_SPAWN_EGG:
+            case RABBIT_SPAWN_EGG:
+            case POLAR_BEAR_SPAWN_EGG:
+            case LLAMA_SPAWN_EGG:
+            case PARROT_SPAWN_EGG:
+            case VILLAGER_SPAWN_EGG:
+            case COD_SPAWN_EGG:
+            case DOLPHIN_SPAWN_EGG:
+            case DROWNED_SPAWN_EGG:
+            case PHANTOM_SPAWN_EGG:
+            case PUFFERFISH_SPAWN_EGG:
+            case SALMON_SPAWN_EGG:
+            case TROPICAL_FISH_SPAWN_EGG:
+            case TURTLE_SPAWN_EGG:
+                return true;
+        }
+        return false;
+    }
+
+
 }

--- a/src/main/java/jp/minecraftuser/ecoegg/listener/PlayerListener.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/listener/PlayerListener.java
@@ -520,7 +520,7 @@ public class PlayerListener extends ListenerFrame {
         }
 
         EntityType type;
-        //もし-MobTypeが-1ならgen_typeからモンスター名を取ってくる
+        //もし-MobTypeが-1ならgen_typeからモンスターの種類を取ってくる
         if (load.getMobType() != -1) {
             switch (load.getMobType()) {
                 case 65:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -28,7 +28,14 @@
 #   - '§0BAT, §8BLAZE, §0CAVE_SPIDER, §8CHICKEN, §0COW, §8CREEPER, §0ENDERMAN, §8GHAST, §0MAGMA_CUBE, §8MUSHROOM_COW, §0OCELOT, §8PIG, §0PIG_ZOMBIE, §8SHEEP, §0SILVERFISH, §8SKELETON, §0SLIME, §8SQUID, §0VILLAGER, §8WITCH, §0WOLF, §8ZOMBIE'
 # □--------------------------------------□
 
-droptable: []
+
+droptable:
+  EnderDragon:
+    amount: 3
+    rate: 1
+  Witch:
+    amount: 1
+    rate: 100
 title: '魔道書「えこたまご」'
 name: '魔道書「えこたまご」'
 author: '神官えこ'


### PR DESCRIPTION
Material.MONSTER_EGG が使えなくなったのでPIG_SPAWN_EGGに暫定的に変更｡
一部のMOBは各スポーンエッグに対応しているが､対応していないMOBはPIG_SPAWN_EGGになる(中身は正常)｡

mob_id(数値)が不明なMOBがいるため､mobの種類をmob_idではなくgen_type(文字列)から取得するよう変更 ｡新しくスポーンエッグに対応したmobはmob_idを-1に設定､以前のmobは今まで通りmob_idから取得｡

注 1.10.2までの保存形式を知らないので互換性があるのかは不明｡(1.12は多分大丈夫)