### PR TITLE
バグ修正や機能追加等

### DIFF
--- a/src/main/java/jp/minecraftuser/ecoegg/EcoEggUtil.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/EcoEggUtil.java
@@ -8,14 +8,12 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 /**
  * EcoEggで使用するユーティリティ
- *
  * @author ecolight
  */
 public class EcoEggUtil {
 
     /**
      * モンスターエッグかどうかを判断する
-     *
      * @param item 判定するアイテムを渡す
      * @return モンスターエッグかどうかの真偽値を返す
      */
@@ -38,24 +36,15 @@ public class EcoEggUtil {
 
     /**
      * モンスターエッグのあるMOBか判定する
-     *
      * @param e エンティティを渡す
      * @return モンスターエッグかどうかの真偽値を返す
      */
-    public static boolean existMonsterEgg(Entity e) {
-        if (Material.matchMaterial("minecraft:" + e.getType().toString() + "_spawn_egg") != null) {
-            return true;
-        } else if (e.getType().toString().equalsIgnoreCase("pig_zombie")) {
-            return true;
-        } else {
-            return false;
-        }
-
+    public static boolean existMonsterEgg(Entity e){
+        return Material.matchMaterial("minecraft:" + e.getType().getName() + "_spawn_egg") != null;
     }
 
     /**
      * 文字列からエンティティタイプを取得する
-     *
      * @param name MOB名称を指定する
      * @return 対応するエンティティタイプを返却する
      */

--- a/src/main/java/jp/minecraftuser/ecoegg/EcoEggUtil.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/EcoEggUtil.java
@@ -8,12 +8,14 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 /**
  * EcoEggで使用するユーティリティ
+ *
  * @author ecolight
  */
 public class EcoEggUtil {
 
     /**
      * モンスターエッグかどうかを判断する
+     *
      * @param item 判定するアイテムを渡す
      * @return モンスターエッグかどうかの真偽値を返す
      */
@@ -36,15 +38,24 @@ public class EcoEggUtil {
 
     /**
      * モンスターエッグのあるMOBか判定する
+     *
      * @param e エンティティを渡す
      * @return モンスターエッグかどうかの真偽値を返す
      */
     public static boolean existMonsterEgg(Entity e) {
-        return Material.matchMaterial("minecraft:" + e.getType().toString() + "_spawn_egg") != null;
+        if (Material.matchMaterial("minecraft:" + e.getType().toString() + "_spawn_egg") != null) {
+            return true;
+        } else if (e.getType().toString().equalsIgnoreCase("pig_zombie")) {
+            return true;
+        } else {
+            return false;
+        }
+
     }
 
     /**
      * 文字列からエンティティタイプを取得する
+     *
      * @param name MOB名称を指定する
      * @return 対応するエンティティタイプを返却する
      */

--- a/src/main/java/jp/minecraftuser/ecoegg/InfoParam.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/InfoParam.java
@@ -16,7 +16,6 @@ public class InfoParam {
     private String str = "";
     private Horse.Style hstyle = null; 
     private Horse.Color hcolor = null;
-    private Horse.Variant hvariant = null;
     
     public InfoParam(Player pl, CommandType type) {
         this.pl = pl;
@@ -34,8 +33,6 @@ public class InfoParam {
     public Horse.Style getHorseStyle() { return this.hstyle; }
     public void setHorseColor(Horse.Color color) { this.hcolor = color; }
     public Horse.Color getHorseColor() { return this.hcolor; }
-    public void setHorseVariant(Horse.Variant var) { this.hvariant = var; }
-    public Horse.Variant getHorseVariant() { return this.hvariant; }
     
     
 }

--- a/src/main/java/jp/minecraftuser/ecoegg/OptionType.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/OptionType.java
@@ -6,5 +6,5 @@ package jp.minecraftuser.ecoegg;
  * @author ecolight
  */
 public enum OptionType {
-    JUMP, SPEED, OWNER, STYLE, COLOR, VARIANT, HEALTH,
+    JUMP, SPEED, OWNER, STYLE, COLOR, HEALTH,
 }

--- a/src/main/java/jp/minecraftuser/ecoegg/command/EceCommand.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/command/EceCommand.java
@@ -3,6 +3,7 @@ package jp.minecraftuser.ecoegg.command;
 
 import jp.minecraftuser.ecoframework.CommandFrame;
 import jp.minecraftuser.ecoframework.PluginFrame;
+import jp.minecraftuser.ecoframework.Utl;
 import org.bukkit.command.CommandSender;
 
 /**
@@ -39,8 +40,8 @@ public class EceCommand extends CommandFrame {
      */
     @Override
     public boolean worker(CommandSender sender, String[] args) {
-        sender.sendMessage("[" + plg.getName()+"] パラメータが不足しています");
+        Utl.sendTagMessage(plg,sender,plg.getName(),"パラメーターが不足しています");
         return true;
     }
-    
+
 }

--- a/src/main/java/jp/minecraftuser/ecoegg/command/EceInfoEggCommand.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/command/EceInfoEggCommand.java
@@ -2,6 +2,7 @@
 package jp.minecraftuser.ecoegg.command;
 
 import jp.minecraftuser.ecoegg.EcoEgg;
+import jp.minecraftuser.ecoegg.EcoEggUtil;
 import jp.minecraftuser.ecoegg.config.LoaderMob;
 import jp.minecraftuser.ecoegg.mob.CreateMob;
 import jp.minecraftuser.ecoegg.mob.InfoMob;
@@ -14,6 +15,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.UUID;
+
 import jp.minecraftuser.ecoframework.Utl;
 
 /**
@@ -55,7 +57,7 @@ public class EceInfoEggCommand extends CommandFrame {
         // モンスターエッグ以外は処理しない
         Player player = ((Player) sender).getPlayer();
         ItemStack item = player.getItemInHand();
-        if (item == null || !isMonsterEgg(item)) {
+        if (!EcoEggUtil.isMonsterEgg(item)) {
             Utl.sendPluginMessage(plg, sender, "モンスターエッグを持った状態でコマンドを入力してください");
             return true;
         }
@@ -77,23 +79,6 @@ public class EceInfoEggCommand extends CommandFrame {
         entity.remove();
 
         return true;
-    }
-
-    public boolean isMonsterEgg(ItemStack item) {
-        if (item == null) {
-            return false;
-        }
-        if (!item.getType().getKey().toString().matches(".*_spawn_egg")) {
-            return false;
-        }
-        ItemMeta meta = item.getItemMeta();
-        if (meta == null) {
-            return false;
-        }
-        String item_name = meta.getDisplayName();
-        if (item_name == null) return false;
-
-        return item_name.startsWith("[EcoEgg]");
     }
 
 

--- a/src/main/java/jp/minecraftuser/ecoegg/command/EceInfoEggCommand.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/command/EceInfoEggCommand.java
@@ -12,7 +12,6 @@ import org.bukkit.Material;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.*;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.UUID;
 

--- a/src/main/java/jp/minecraftuser/ecoegg/command/EceReloadCommand.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/command/EceReloadCommand.java
@@ -44,5 +44,5 @@ public class EceReloadCommand extends CommandFrame {
         sender.sendMessage("[" + plg.getName()+"] コンフィグリロード");
         return true;
     }
-    
+
 }

--- a/src/main/java/jp/minecraftuser/ecoegg/command/EceReloadCommand.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/command/EceReloadCommand.java
@@ -3,6 +3,7 @@ package jp.minecraftuser.ecoegg.command;
 
 import jp.minecraftuser.ecoframework.CommandFrame;
 import jp.minecraftuser.ecoframework.PluginFrame;
+import jp.minecraftuser.ecoframework.Utl;
 import org.bukkit.command.CommandSender;
 
 /**
@@ -41,7 +42,7 @@ public class EceReloadCommand extends CommandFrame {
     public boolean worker(CommandSender sender, String[] args) {
         // リロード
         conf.reload();
-        sender.sendMessage("[" + plg.getName()+"] コンフィグリロード");
+        Utl.sendTagMessage(plg,sender,plg.getName(),"コンフィグリロード");
         return true;
     }
 

--- a/src/main/java/jp/minecraftuser/ecoegg/command/EceSetCommand.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/command/EceSetCommand.java
@@ -20,7 +20,7 @@ public class EceSetCommand extends CommandFrame {
 
     /**
      * コンストラクタ
-     * @param plg_ プラグインインスタンス
+     * @param plg_  プラグインインスタンス
      * @param name_ コマンド名
      */
     public EceSetCommand(PluginFrame plg_, String name_) {
@@ -39,44 +39,47 @@ public class EceSetCommand extends CommandFrame {
     /**
      * 処理実行部
      * @param sender コマンド送信者
-     * @param args パラメタ
+     * @param args   パラメタ
      * @return コマンド処理成否
      */
     @Override
     public boolean worker(CommandSender sender, String[] args) {
         InfoParam param = new InfoParam((Player) sender, CommandType.SET);
 
-        if (args[0].equalsIgnoreCase("jump")) {
-            param.setOpt(OptionType.JUMP);
-            param.setVal(Double.parseDouble(args[1]));
-        } else if (args[0].equalsIgnoreCase("speed")) {
-            param.setOpt(OptionType.SPEED);
-            param.setVal(Double.parseDouble(args[1]));
-        } else if (args[0].equalsIgnoreCase("color")) {
-            param.setOpt(OptionType.COLOR);
-            if (Horse.Color.valueOf(args[1]) == null) return false;
-            param.setHorseColor(Horse.Color.valueOf(args[1]));
-        } else if (args[0].equalsIgnoreCase("health")) {
-            param.setOpt(OptionType.HEALTH);
-            param.setVal(Double.parseDouble(args[1]));
-        } else if (args[0].equalsIgnoreCase("owner")) {
-            param.setOpt(OptionType.OWNER);
-            param.setStr(args[1]);
-        } else if (args[0].equalsIgnoreCase("style")) {
-            param.setOpt(OptionType.STYLE);
-            if (Horse.Style.valueOf(args[1]) == null) return false;
-            param.setHorseStyle(Horse.Style.valueOf(args[1]));
-        } else if (args[0].equalsIgnoreCase("variant")) {
-            param.setOpt(OptionType.VARIANT);
-            if (Horse.Variant.valueOf(args[1]) == null) return false;
-            param.setHorseVariant(Horse.Variant.valueOf(args[1]));
-        } else {
-            return false;
+        if (args.length <= 1) {
+            Utl.sendPluginMessage(plg, sender, "引数が足りません");
+            return true;
         }
-        ((EcoEgg)plg).setParamUser(param);
+        try {
+            if (args[0].equalsIgnoreCase("jump")) {
+                param.setOpt(OptionType.JUMP);
+                param.setVal(Double.parseDouble(args[1]));
+            } else if (args[0].equalsIgnoreCase("speed")) {
+                param.setOpt(OptionType.SPEED);
+                param.setVal(Double.parseDouble(args[1]));
+            } else if (args[0].equalsIgnoreCase("color")) {
+                param.setOpt(OptionType.COLOR);
+                param.setHorseColor(Horse.Color.valueOf(args[1]));
+            } else if (args[0].equalsIgnoreCase("health")) {
+                param.setOpt(OptionType.HEALTH);
+                param.setVal(Double.parseDouble(args[1]));
+            } else if (args[0].equalsIgnoreCase("owner")) {
+                param.setOpt(OptionType.OWNER);
+                param.setStr(args[1]);
+            } else if (args[0].equalsIgnoreCase("style")) {
+                param.setOpt(OptionType.STYLE);
+                param.setHorseStyle(Horse.Style.valueOf(args[1]));
+            } else {
+                return false;
+            }
+        } catch (IllegalArgumentException e) {
+            Utl.sendPluginMessage(plg, sender, "引数に不正な値が渡されました");
+            return true;
+        }
+        ((EcoEgg) plg).setParamUser(param);
 
         Utl.sendPluginMessage(plg, sender, "対象の動物(馬)を右クリックして下さい");
         return true;
     }
-    
+
 }

--- a/src/main/java/jp/minecraftuser/ecoegg/listener/CancelUseEggListener.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/listener/CancelUseEggListener.java
@@ -52,11 +52,11 @@ public class CancelUseEggListener extends ListenerFrame {
      */
     @EventHandler(priority = EventPriority.LOWEST)
     public void CreatureRightClick(PlayerInteractEntityEvent event) {
-        Player plyaer = event.getPlayer();
-        ItemStack item = plyaer.getItemInHand();
+        Player player = event.getPlayer();
+        ItemStack item = player.getItemInHand();
         if(EcoEggUtil.isMonsterEgg(item)){
-            Utl.sendPluginMessage(plg,plyaer,"エンティティに対してモンスターエッグが使用されたので抑止しました");
-            Utl.sendPluginMessage(plg,plyaer,"おかしな子供を生みたい場合はオフハンドにもって使用してください");
+            Utl.sendPluginMessage(plg,player,"エンティティに対してモンスターエッグが使用されたので抑止しました");
+            Utl.sendPluginMessage(plg,player,"おかしな子供を生みたい場合はオフハンドにもって使用してください");
             event.setCancelled(true);
         }
 

--- a/src/main/java/jp/minecraftuser/ecoegg/listener/CancelUseEggListener.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/listener/CancelUseEggListener.java
@@ -24,7 +24,7 @@ public class CancelUseEggListener extends ListenerFrame  {
 
     /**
      * MOBスポーンイベントハンドラ
-     * @param event 
+     * @param event
      */
     @EventHandler(priority = EventPriority.LOWEST)
     public void CreatureSpawn(CreatureSpawnEvent event) {

--- a/src/main/java/jp/minecraftuser/ecoegg/listener/CancelUseEggListener.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/listener/CancelUseEggListener.java
@@ -1,21 +1,28 @@
 
 package jp.minecraftuser.ecoegg.listener;
 
+import jp.minecraftuser.ecoegg.EcoEggUtil;
 import jp.minecraftuser.ecoframework.PluginFrame;
 import jp.minecraftuser.ecoframework.ListenerFrame;
+import jp.minecraftuser.ecoframework.Utl;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.entity.CreatureSpawnEvent;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.inventory.ItemStack;
 
 /**
  * EcoEggドロップリスナクラス
+ *
  * @author ecolight
  */
-public class CancelUseEggListener extends ListenerFrame  {
+public class CancelUseEggListener extends ListenerFrame {
     /**
      * コンストラクタ
-     * @param plg_ プラグインインスタンス
+     *
+     * @param plg_  プラグインインスタンス
      * @param name_ 名前
      */
     public CancelUseEggListener(PluginFrame plg_, String name_) {
@@ -24,6 +31,7 @@ public class CancelUseEggListener extends ListenerFrame  {
 
     /**
      * MOBスポーンイベントハンドラ
+     *
      * @param event
      */
     @EventHandler(priority = EventPriority.LOWEST)
@@ -35,5 +43,22 @@ public class CancelUseEggListener extends ListenerFrame  {
         if (custom_name.startsWith("[EcoEgg]")) {
             event.setCancelled(true);
         }
+    }
+
+    /**
+     * エンエィティ右クリックイベントハンドラ
+     *
+     * @param event
+     */
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void CreatureRightClick(PlayerInteractEntityEvent event) {
+        Player plyaer = event.getPlayer();
+        ItemStack item = plyaer.getItemInHand();
+        if(EcoEggUtil.isMonsterEgg(item)){
+            Utl.sendPluginMessage(plg,plyaer,"エンティティに対してモンスターエッグが使用されたので抑止しました");
+            Utl.sendPluginMessage(plg,plyaer,"おかしな子供を生みたい場合はオフハンドにもって使用してください");
+            event.setCancelled(true);
+        }
+
     }
 }

--- a/src/main/java/jp/minecraftuser/ecoegg/listener/CommandListener.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/listener/CommandListener.java
@@ -63,7 +63,7 @@ public class CommandListener extends ListenerFrame {
                 case HORSE:
                     break;
                 default:
-                    Utl.sendPluginMessage(plg, ent, "setコマンドの対象外のエンティティです");
+                    Utl.sendPluginMessage(plg, pl, "setコマンドの対象外のエンティティです");
                     return;
             }
             InfoParam param;
@@ -74,28 +74,28 @@ public class CommandListener extends ListenerFrame {
                     switch (param.getOpt()) {
                         case JUMP:
                             horse.setJumpStrength(param.getVal());
-                            Utl.sendPluginMessage(plg, ent, "ジャンプ力[" + horse.getJumpStrength() + "]を設定しました");
+                            Utl.sendPluginMessage(plg, pl, "ジャンプ力[" + horse.getJumpStrength() + "]を設定しました");
                             break;
                         case SPEED:
                             horse.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED).setBaseValue(param.getVal());
-                            Utl.sendPluginMessage(plg, ent, "スピード[" + horse.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED).getBaseValue() + "]を設定しました");
+                            Utl.sendPluginMessage(plg, pl, "スピード[" + horse.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED).getBaseValue() + "]を設定しました");
                             break;
                         case HEALTH:
                             horse.setMaxHealth(param.getVal());
-                            Utl.sendPluginMessage(plg, ent, "HP最大値[" + horse.getMaxHealth() + "]を設定しました");
+                            Utl.sendPluginMessage(plg, pl, "HP最大値[" + horse.getMaxHealth() + "]を設定しました");
                             break;
                         case OWNER:
                             if (plg.getServer().getPlayerExact(param.getStr()) == null) return;
                             horse.setOwner(plg.getServer().getPlayerExact(param.getStr()));
-                            Utl.sendPluginMessage(plg, ent, "飼い主[" + horse.getOwner().getName() + "]を設定しました");
+                            Utl.sendPluginMessage(plg, pl, "飼い主[" + horse.getOwner().getName() + "]を設定しました");
                             break;
                         case STYLE:
                             horse.setStyle(param.getHorseStyle());
-                            Utl.sendPluginMessage(plg, ent, "スタイル[" + horse.getStyle().name() + "]を設定しました");
+                            Utl.sendPluginMessage(plg, pl, "スタイル[" + horse.getStyle().name() + "]を設定しました");
                             break;
                         case COLOR:
                             horse.setColor(param.getHorseColor());
-                            Utl.sendPluginMessage(plg, ent, "色[" + horse.getColor().name() + "]を設定しました");
+                            Utl.sendPluginMessage(plg, pl, "色[" + horse.getColor().name() + "]を設定しました");
                             break;
                     }
                     break;

--- a/src/main/java/jp/minecraftuser/ecoegg/listener/CommandListener.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/listener/CommandListener.java
@@ -68,7 +68,7 @@ public class CommandListener extends ListenerFrame {
             }
             InfoParam param;
             switch (ent.getType()) {
-            case HORSE:
+                case HORSE:
                     Horse horse = (Horse) ent;
                     param = ((EcoEgg) plg).getParamUser(pl);
                     switch (param.getOpt()) {

--- a/src/main/java/jp/minecraftuser/ecoegg/listener/CommandListener.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/listener/CommandListener.java
@@ -97,10 +97,6 @@ public class CommandListener extends ListenerFrame {
                             horse.setColor(param.getHorseColor());
                             Utl.sendPluginMessage(plg, ent, "色[" + horse.getColor().name() + "]を設定しました");
                             break;
-                        case VARIANT:
-                            horse.setVariant(param.getHorseVariant());
-                            Utl.sendPluginMessage(plg, ent, "Variant[" + horse.getVariant().name() + "]を設定しました");
-                            break;
                     }
                     break;
             }

--- a/src/main/java/jp/minecraftuser/ecoegg/listener/EcoEggDropListener.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/listener/EcoEggDropListener.java
@@ -91,19 +91,6 @@ public class EcoEggDropListener extends ListenerFrame  {
         }
     }
 
-    /**
-     * MOBスポーンイベントハンドラ
-     * @param event 
-     */
-    @EventHandler(priority = EventPriority.LOWEST)
-    public void CreatureSpawn(CreatureSpawnEvent event) {
-        LivingEntity ent = event.getEntity();
-        if (ent == null) return;
-        String custom_name = ent.getCustomName();
-        if (custom_name == null) return;
-        if (custom_name.startsWith("[EcoEgg]")) {
-            event.setCancelled(true);
-        }
-    }
+
 
 }

--- a/src/main/java/jp/minecraftuser/ecoegg/listener/EcoEggDropListener.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/listener/EcoEggDropListener.java
@@ -15,7 +15,6 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
-import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.inventory.ItemStack;
 

--- a/src/main/java/jp/minecraftuser/ecoegg/listener/HatchingListener.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/listener/HatchingListener.java
@@ -128,11 +128,8 @@ public class HatchingListener extends ListenerFrame {
         //----------------------------------------------------------------------
         event.setCancelled(true);
         ItemStack egg;
-        if (ent.getType().toString().equalsIgnoreCase("pig_zombie")) {
-            egg = new ItemStack(Material.matchMaterial("minecraft:zombie_pigman_spawn_egg"));//雑い
-        } else {
-            egg = new ItemStack(Material.matchMaterial("minecraft:" + ent.getType() + "_spawn_egg"));//雑い
-        }
+
+        egg = new ItemStack(Material.matchMaterial("minecraft:" + ent.getType().getName() + "_spawn_egg"));//雑い
 
         LoaderMob save = new LoaderMob((EcoEgg) plg, le.getUniqueId());
         SaveMob saveMob = new SaveMob(le, pl, loc, save, plg);

--- a/src/main/java/jp/minecraftuser/ecoegg/listener/HatchingListener.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/listener/HatchingListener.java
@@ -109,7 +109,7 @@ public class HatchingListener extends ListenerFrame {
         PlayerInventory pi = pl.getInventory();
         ItemStack is = pi.getItemInMainHand();
         if ((reject) && (!pl.isOp())) {
-            Utl.sendPluginMessage(plg, ent, "他のプレイヤーの動物には力が及びませんでした");
+            Utl.sendPluginMessage(plg, event.getPlayer(), "他のプレイヤーの動物には力が及びませんでした");
             if (pl.getGameMode() != GameMode.CREATIVE) {
                 if (is.getAmount() == 1) {
                     pi.setItemInMainHand(new ItemStack(Material.AIR));
@@ -146,7 +146,7 @@ public class HatchingListener extends ListenerFrame {
                 ii++;
             }
             if (ii == pi.getSize()) {
-                pl.sendMessage(ChatColor.AQUA + "[EcoEgg] インベントリに空きが無いので使用できません");
+                Utl.sendPluginMessage(plg, pl, ChatColor.AQUA + "インベントリに空きが無いので使用できません");
                 event.setCancelled(true);
                 return;
             } else {
@@ -164,7 +164,8 @@ public class HatchingListener extends ListenerFrame {
 
         le.remove();
         pl.getWorld().strikeLightningEffect(loc);
-        pl.sendMessage(ChatColor.AQUA + "[EcoEgg] MOBをたまごに変換しました");
+
+        Utl.sendPluginMessage(plg, pl, ChatColor.AQUA + "MOBをたまごに変換しました");
         log.info("ChangeMobEgg[" + pl.getName() + "]" + pl.getLocation().toString() + ",MOB:" + (byte) ent.getType().getTypeId());
         event.setCancelled(true);
     }
@@ -209,8 +210,9 @@ public class HatchingListener extends ListenerFrame {
 
         // インターバルの監視
         Date date = new Date();
-        if (date.getTime() < load.getDate() + 1000 * 10) {
-            Utl.sendPluginMessage(plg, event.getPlayer(), "再使用まであと " + (10 - (date.getTime() - load.getDate()) / 1000) + " 秒必要です");
+        int wait_time = 10;
+        if (date.getTime() < load.getDate() + 1000 * wait_time) {
+            Utl.sendPluginMessage(plg, event.getPlayer(), "再使用まであと " + (wait_time - (date.getTime() - load.getDate()) / 1000) + " 秒必要です");
             event.setCancelled(true);
             return;
         }
@@ -233,14 +235,22 @@ public class HatchingListener extends ListenerFrame {
 
         CreateMob createMob = new CreateMob(player, block.getType(), loc, load, plg);
         LivingEntity entity = createMob.create();
+        if (createMob.isCancel()) {
+            entity.remove();
+            event.setCancelled(true);
+            return;
+        }
+
 
         // MOBスポーン後の処理
         // 保存yamlに使用済みをマークする
         SimpleDateFormat sdf1 = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
         load.saveUse(player.getName(), entity.getType().name(), sdf1.format(date));
+        load.setUsed(true);
 
         event.setCancelled(true);
-        if (player.getGameMode() != GameMode.CREATIVE) player.getInventory().setItemInMainHand(new ItemStack(Material.AIR));
+        if (player.getGameMode() != GameMode.CREATIVE)
+            player.getInventory().setItemInMainHand(new ItemStack(Material.AIR));
         Utl.sendPluginMessage(plg, event.getPlayer(), entity.getType().name() + "を出現させました");
     }
 }

--- a/src/main/java/jp/minecraftuser/ecoegg/listener/HatchingListener.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/listener/HatchingListener.java
@@ -65,6 +65,7 @@ public class HatchingListener extends ListenerFrame {
 
         //モンスターエッグに変換できない場合はキャンセル
         if (!EcoEggUtil.existMonsterEgg(ent)) {
+            Utl.sendPluginMessage(plg, pl, "EcoEgg非対応モンスターです");
             return;
         }
 
@@ -125,10 +126,20 @@ public class HatchingListener extends ListenerFrame {
         //----------------------------------------------------------------------
         // MOBたまご生成
         //----------------------------------------------------------------------
-        ItemStack egg = new ItemStack(Material.matchMaterial("minecraft:" + ent.getType() + "_spawn_egg"));//雑い
+        event.setCancelled(true);
+        ItemStack egg;
+        if (ent.getType().toString().equalsIgnoreCase("pig_zombie")) {
+            egg = new ItemStack(Material.matchMaterial("minecraft:zombie_pigman_spawn_egg"));//雑い
+        } else {
+            egg = new ItemStack(Material.matchMaterial("minecraft:" + ent.getType() + "_spawn_egg"));//雑い
+        }
+
         LoaderMob save = new LoaderMob((EcoEgg) plg, le.getUniqueId());
         SaveMob saveMob = new SaveMob(le, pl, loc, save, plg);
         saveMob.save();
+        if (saveMob.isCancel()) {
+            return;
+        }
 
         ItemMeta im = egg.getItemMeta();
         im.setDisplayName("[EcoEgg]," + le.getUniqueId().getMostSignificantBits() + "," + le.getUniqueId().getLeastSignificantBits());
@@ -147,7 +158,7 @@ public class HatchingListener extends ListenerFrame {
             }
             if (ii == pi.getSize()) {
                 Utl.sendPluginMessage(plg, pl, ChatColor.AQUA + "インベントリに空きが無いので使用できません");
-                event.setCancelled(true);
+
                 return;
             } else {
                 is.setAmount(is.getAmount() - 1);
@@ -167,7 +178,7 @@ public class HatchingListener extends ListenerFrame {
 
         Utl.sendPluginMessage(plg, pl, ChatColor.AQUA + "MOBをたまごに変換しました");
         log.info("ChangeMobEgg[" + pl.getName() + "]" + pl.getLocation().toString() + ",MOB:" + (byte) ent.getType().getTypeId());
-        event.setCancelled(true);
+
     }
 
     /**
@@ -193,6 +204,7 @@ public class HatchingListener extends ListenerFrame {
 
         // エコエッグの表記で始まるか
         if (!item_name.startsWith("[EcoEgg]")) return;
+        event.setCancelled(true);
         String[] token = item_name.split(",");
         String most = token[token.length - 2];
         String least = token[token.length - 1];
@@ -204,7 +216,7 @@ public class HatchingListener extends ListenerFrame {
         if (load.getUsed() && (!event.getPlayer().isOp())) {
             log.info("使用済みたまご利用:" + most + "," + least + "[" + event.getPlayer().getName() + "]");
             Utl.sendPluginMessage(plg, event.getPlayer(), "管理者に通報されました：使用済みたまご利用:" + most + "," + least + "[" + event.getPlayer().getName() + "]");
-            event.setCancelled(true);
+
             return;
         }
 
@@ -213,14 +225,13 @@ public class HatchingListener extends ListenerFrame {
         int wait_time = 10;
         if (date.getTime() < load.getDate() + 1000 * wait_time) {
             Utl.sendPluginMessage(plg, event.getPlayer(), "再使用まであと " + (wait_time - (date.getTime() - load.getDate()) / 1000) + " 秒必要です");
-            event.setCancelled(true);
+
             return;
         }
 
         // 一応本のクリック判定をキャンセル？
         Block block = event.getClickedBlock();
         if (block == null) {
-            event.setCancelled(true);
             return;
         }
 
@@ -237,7 +248,6 @@ public class HatchingListener extends ListenerFrame {
         LivingEntity entity = createMob.create();
         if (createMob.isCancel()) {
             entity.remove();
-            event.setCancelled(true);
             return;
         }
 
@@ -248,9 +258,9 @@ public class HatchingListener extends ListenerFrame {
         load.saveUse(player.getName(), entity.getType().name(), sdf1.format(date));
         load.setUsed(true);
 
-        event.setCancelled(true);
-        if (player.getGameMode() != GameMode.CREATIVE)
+        if (player.getGameMode() != GameMode.CREATIVE) {
             player.getInventory().setItemInMainHand(new ItemStack(Material.AIR));
+        }
         Utl.sendPluginMessage(plg, event.getPlayer(), entity.getType().name() + "を出現させました");
     }
 }

--- a/src/main/java/jp/minecraftuser/ecoegg/listener/HatchingListener.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/listener/HatchingListener.java
@@ -66,7 +66,6 @@ public class HatchingListener extends ListenerFrame {
 
         //モンスターエッグに変換できない場合はキャンセル
         if (!EcoEggUtil.existMonsterEgg(ent)) {
-            Utl.sendPluginMessage(plg, pl, "EcoEgg非対応モンスターです");
             return;
         }
 

--- a/src/main/java/jp/minecraftuser/ecoegg/listener/HatchingListener.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/listener/HatchingListener.java
@@ -25,6 +25,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.inventory.meta.BookMeta;
@@ -84,7 +85,7 @@ public class HatchingListener extends ListenerFrame {
             ItemStack is = pl.getItemInHand();
             if (is.getType() != Material.WRITTEN_BOOK) return;
             // 魔道書の記述が正しいか
-            BookMeta meta = (BookMeta) pl.getItemInHand().getItemMeta();
+            BookMeta meta = (BookMeta) is.getItemMeta();
 
             if (!meta.getAuthor().equals(eceConf.getAuthor())) return;
             if (!meta.getTitle().equals(eceConf.getTitle())) return;
@@ -256,7 +257,11 @@ public class HatchingListener extends ListenerFrame {
         load.setUsed(true);
 
         if (player.getGameMode() != GameMode.CREATIVE) {
-            player.getInventory().setItemInMainHand(new ItemStack(Material.AIR));
+            if (event.getHand() == EquipmentSlot.HAND) {
+                player.getInventory().setItemInMainHand(new ItemStack(Material.AIR));
+            } else {
+                player.getInventory().setItemInOffHand(new ItemStack(Material.AIR));
+            }
         }
         Utl.sendPluginMessage(plg, event.getPlayer(), entity.getType().name() + "を出現させました");
     }

--- a/src/main/java/jp/minecraftuser/ecoegg/mob/CreateMob.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/mob/CreateMob.java
@@ -11,7 +11,6 @@ import org.bukkit.attribute.Attribute;
 import org.bukkit.craftbukkit.v1_13_R2.entity.CraftVillager;
 import org.bukkit.entity.*;
 import org.bukkit.inventory.MerchantRecipe;
-import org.bukkit.plugin.Plugin;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -54,6 +53,12 @@ public class CreateMob {
         }
 
         entity = (LivingEntity) player.getWorld().spawnEntity(loc, type);
+        if(material == Material.SOUL_SAND){
+            Utl.sendPluginMessage(plg,player,"ノーマルのモンスターエッグとして使用しました");
+            return entity;
+        }
+
+
         entity.setMaxHealth(load.getMaxHealth());
         entity.setHealth(load.getHealth());
 

--- a/src/main/java/jp/minecraftuser/ecoegg/mob/CreateMob.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/mob/CreateMob.java
@@ -2,6 +2,8 @@ package jp.minecraftuser.ecoegg.mob;
 
 import jp.minecraftuser.ecoegg.SimpleTradeRecipe;
 import jp.minecraftuser.ecoegg.config.LoaderMob;
+import jp.minecraftuser.ecoframework.PluginFrame;
+import jp.minecraftuser.ecoframework.Utl;
 import net.minecraft.server.v1_13_R2.EntityVillager;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -23,9 +25,10 @@ public class CreateMob {
     private Material material;
     private Location loc;
     private LoaderMob load;
-    private Plugin plg;
+    private PluginFrame plg;
+    private boolean cancel = false;
 
-    public CreateMob(Player player, Material material, Location loc, LoaderMob load, Plugin plg) {
+    public CreateMob(Player player, Material material, Location loc, LoaderMob load, PluginFrame plg) {
         this.player = player;
         this.material = material;
         this.loc = loc;
@@ -42,16 +45,15 @@ public class CreateMob {
         }
 
         if (isOldFormatEgg()) {
-            player.sendMessage("旧式のモンスターエッグです");
+            Utl.sendPluginMessage(plg, player, "旧式のモンスターエッグです");
             if (type == EntityType.HORSE && Horse.Variant.valueOf(load.getHorseVariant().name()) != Horse.Variant.HORSE) {
                 EntityType new_entity_type = EntityType.valueOf(load.getHorseVariant().name());
-                player.sendMessage("EntityTypeを変更" + type + "->" + new_entity_type);
+                Utl.sendPluginMessage(plg, player, "EntityTypeを変更" + type + "->" + new_entity_type);
                 type = new_entity_type;
             }
         }
 
         entity = (LivingEntity) player.getWorld().spawnEntity(loc, type);
-        load.setUsed(true);
         entity.setMaxHealth(load.getMaxHealth());
         entity.setHealth(load.getHealth());
 
@@ -139,7 +141,7 @@ public class CreateMob {
     private void createVillager() {
         Villager villager = (Villager) entity;
         if (isOldFormatEgg()) {
-            player.sendMessage("トレード内容復元処理をスキップしました");
+            Utl.sendPluginMessage(plg, player, "トレード内容復元処理をスキップしました");
             return;
         }
 
@@ -161,7 +163,9 @@ public class CreateMob {
         try {
             setVillagerCareerLevel(villager, load.getVillagerCareerLevel());
         } catch (NoSuchFieldException | IllegalAccessException e) {
-            player.sendMessage(e.toString());
+            cancel = true;
+            Utl.sendPluginMessage(plg, player, "CareerLevelの復元処理に失敗しました 管理者に報告してください");
+
         }
     }
 
@@ -172,7 +176,7 @@ public class CreateMob {
 
         if (material == Material.CARROTS) ownerreset = true;
         if (ownerreset) {
-            player.sendMessage("オーナーをリセットしました");
+            Utl.sendPluginMessage(plg, player, "オーナーをリセットしました");
             tame_entity.setOwner(player);
         } else {
             if (owner != null) tame_entity.setOwner(plg.getServer().getOfflinePlayer(owner));
@@ -202,5 +206,9 @@ public class CreateMob {
 
     private boolean isOldFormatEgg() {
         return load.getPluginVersion() == null;//雑い
+    }
+
+    public boolean isCancel() {
+        return this.cancel;
     }
 }

--- a/src/main/java/jp/minecraftuser/ecoegg/mob/InfoMob.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/mob/InfoMob.java
@@ -8,6 +8,7 @@ import org.bukkit.entity.*;
 import org.bukkit.inventory.ItemStack;
 
 import java.lang.reflect.Field;
+
 import jp.minecraftuser.ecoframework.PluginFrame;
 import jp.minecraftuser.ecoframework.Utl;
 
@@ -81,7 +82,7 @@ public class InfoMob {
     private void showParrot() {
         Parrot parrot = (Parrot) entity;
         Utl.sendPluginMessage(plg, player, "Variant:" + parrot.getVariant());
-   }
+    }
 
     public void showTropicalFish() {
         TropicalFish tropicalFish = (TropicalFish) entity;
@@ -125,7 +126,7 @@ public class InfoMob {
         Utl.sendPluginMessage(plg, player, "Riches:" + villager.getRiches());
 
         try {
-            player.sendMessage("CareerLevel:" + getVillagerCareerLevel(villager));
+            Utl.sendPluginMessage(plg, player, "CareerLevel:" + getVillagerCareerLevel(villager));
         } catch (NoSuchFieldException | IllegalAccessException e) {
             e.printStackTrace();
         }

--- a/src/main/java/jp/minecraftuser/ecoegg/mob/SaveMob.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/mob/SaveMob.java
@@ -11,7 +11,6 @@ import org.bukkit.attribute.Attribute;
 import org.bukkit.craftbukkit.v1_13_R2.entity.CraftVillager;
 import org.bukkit.entity.*;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.plugin.Plugin;
 
 import java.lang.reflect.Field;
 import java.util.*;

--- a/src/main/java/jp/minecraftuser/ecoegg/mob/SaveMob.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/mob/SaveMob.java
@@ -31,7 +31,7 @@ public class SaveMob {
         this.plg = plg;
     }
 
-    public LivingEntity save() {
+    public void save() {
         save.setUsed(false);
         save.setMobType((byte) entity.getType().getTypeId());
         save.setCustomName(entity.getCustomName());
@@ -70,7 +70,6 @@ public class SaveMob {
             saveAnimal();
         }
 
-        return this.entity;
     }
 
     private void saveRabbit() {

--- a/src/main/java/jp/minecraftuser/ecoegg/mob/SaveMob.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/mob/SaveMob.java
@@ -3,6 +3,7 @@ package jp.minecraftuser.ecoegg.mob;
 import jp.minecraftuser.ecoegg.SimpleTradeRecipe;
 import jp.minecraftuser.ecoegg.config.LoaderMob;
 import jp.minecraftuser.ecoframework.PluginFrame;
+import jp.minecraftuser.ecoframework.Utl;
 import net.minecraft.server.v1_13_R2.EntityVillager;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -23,6 +24,7 @@ public class SaveMob {
     private Location loc;
     private LoaderMob save;
     private PluginFrame plg;
+    private boolean cancel;
 
     public SaveMob(LivingEntity ent, Player player, Location loc, LoaderMob save, PluginFrame plg) {
         this.entity = ent;
@@ -118,7 +120,7 @@ public class SaveMob {
             }
             entity.getWorld().dropItem(loc, item);
         }
-        
+
         // 保存
         save.setMaxDomestication(horse.getMaxDomestication());
         save.setDomestication(horse.getDomestication());
@@ -148,13 +150,14 @@ public class SaveMob {
         try {
             save.setVillagerCareerLevel(getVillagerCareerLevel(villager));
         } catch (NoSuchFieldException | IllegalAccessException e) {
-            e.printStackTrace();
+            Utl.sendPluginMessage(plg, player, "CareerLevelの復元処理に失敗しました 管理者に報告してください");
+            cancel = true;
         }
     }
 
     private void saveTame() {
         Tameable tame_entity = (Tameable) entity;
-        
+
         // 保存
         if (tame_entity.getOwner() != null) save.setOwner(tame_entity.getOwner().getName());
         save.setTamed(tame_entity.isTamed());
@@ -174,5 +177,9 @@ public class SaveMob {
         Field careerLevelField = EntityVillager.class.getDeclaredField("careerLevel");
         careerLevelField.setAccessible(true);
         return careerLevelField.getInt(entityVillager);
+    }
+
+    public boolean isCancel() {
+        return cancel;
     }
 }

--- a/src/main/java/jp/minecraftuser/ecoegg/mob/SaveMob.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/mob/SaveMob.java
@@ -2,6 +2,7 @@ package jp.minecraftuser.ecoegg.mob;
 
 import jp.minecraftuser.ecoegg.SimpleTradeRecipe;
 import jp.minecraftuser.ecoegg.config.LoaderMob;
+import jp.minecraftuser.ecoframework.PluginFrame;
 import net.minecraft.server.v1_13_R2.EntityVillager;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -21,9 +22,9 @@ public class SaveMob {
 
     private Location loc;
     private LoaderMob save;
-    private Plugin plg;
+    private PluginFrame plg;
 
-    public SaveMob(LivingEntity ent, Player player, Location loc, LoaderMob save, Plugin plg) {
+    public SaveMob(LivingEntity ent, Player player, Location loc, LoaderMob save, PluginFrame plg) {
         this.entity = ent;
         this.player = player;
         this.loc = loc;


### PR DESCRIPTION
機能追加
ソウルサンドに対してモンスターエッグ(EcoEgg)を使用すると､ノーマルのモンスターエッグとして機能するようにした
バグ修正
スポーンしたエンティティに対してメッセージを送信していたのを修正
ゾンビピッグマンがスポーン出来ていなかったのを修正
ecosetコマンドを使用する際､不正な値を送信するとサーバー側でエラーを吐いていたのを修正
モンスターエッグ(EcoEgg)をオフハンドに入れた状態で使うとモンスターエッグを消費せずにモンスターを出現出来たのを修正