### PR TITLE
 Careerが指定されてない旧タイプの村人の職業を取得しようとするとIllegalArgumentException

### DIFF
--- a/src/main/java/jp/minecraftuser/ecoegg/mob/InfoMob.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/mob/InfoMob.java
@@ -166,15 +166,16 @@ public class InfoMob {
         });
         Utl.sendPluginMessage(plg, player, "----トレード内容ここまで----");
 
-        if (villager.getCareer() == null) {
+        try {
+            Utl.sendPluginMessage(plg, player, "Career:" + villager.getCareer());
+            Utl.sendPluginMessage(plg, player, "Profession:" + villager.getProfession());
+            Utl.sendPluginMessage(plg, player, "Riches:" + villager.getRiches());
+
+        } catch (IllegalArgumentException e) {
             Utl.sendPluginMessage(plg, player, "旧タイプの村人な為､職業を取得できませんでした");
             Utl.sendPluginMessage(plg, player, "取引を更新すると職業を取得できます");
             return;
         }
-
-        Utl.sendPluginMessage(plg, player, "Career:" + villager.getCareer());
-        Utl.sendPluginMessage(plg, player, "Profession:" + villager.getProfession());
-        Utl.sendPluginMessage(plg, player, "Riches:" + villager.getRiches());
 
 
         try {

--- a/src/main/java/jp/minecraftuser/ecoegg/mob/SaveMob.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/mob/SaveMob.java
@@ -174,15 +174,16 @@ public class SaveMob {
 
         // 保存
         save.setVillagerTradeList(simpleTradeRecipeList);
-        if (villager.getCareer() == null) {
+        try {
+            save.setVillagerCareer(villager.getCareer());
+            save.setVillagerRiches(villager.getRiches());
+            save.setVillagerProfession(villager.getProfession());
+        } catch (IllegalArgumentException e) {
             Utl.sendPluginMessage(plg, player, "旧タイプの村人な為､職業の取得に失敗しました｡");
             Utl.sendPluginMessage(plg, player, "取引を更新してください｡");
             cancel = true;
             return;
         }
-        save.setVillagerCareer(villager.getCareer());
-        save.setVillagerRiches(villager.getRiches());
-        save.setVillagerProfession(villager.getProfession());
 
         try {
             save.setVillagerCareerLevel(getVillagerCareerLevel(villager));


### PR DESCRIPTION
吐いていたのをcatchして雑に修正