### PR TITLE
エンダードラゴン討伐時にえこたまごドロップ数が 3(n+1) 冊となる問題を修正

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>jp.minecraftuser</groupId>
     <artifactId>EcoEgg</artifactId>
-    <version>0.11</version>
+    <version>0.12</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/jp/minecraftuser/ecoegg/listener/EcoEggDropListener.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/listener/EcoEggDropListener.java
@@ -71,15 +71,16 @@ public class EcoEggDropListener extends ListenerFrame  {
         // アイテム情報生成
         for (int cnt = 0; cnt < loopcnt; cnt++) {
             //------------------------------------------------------------------
-            // 指定した確立でドロップする(configで変更可能)
+            // 指定した確率でドロップする(configで変更可能)
             //------------------------------------------------------------------
+            int amount = param.getAmount();
             Random rnd = new Random();
             if (rnd.nextInt(param.getRate()) != 0) continue;
             if ((loopcnt > 1) && (param.getRate() == 1)) {
-                param.setAmount(param.getAmount() + loopcnt - 1);
+                amount += loopcnt - 1;
                 loopcnt = 1;
             }
-            for (int i = 0; i < param.getAmount(); i++) {
+            for (int i = 0; i < amount; i++) {
                 // ドロップ処理
                 LivingEntity ent = event.getEntity();
                 Location loc = ent.getLocation();


### PR DESCRIPTION
param.rate=1のmobを討伐した際に、param.amountがドロップ増加のレベル分増加したまま初期化されずに維持される(えこたまごドロップ数が lv*(n+1) 冊となる)問題を修正