### PR TITLE
村人のエコたまごに発生していた下記の不具合を修正

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>jp.minecraftuser</groupId>
     <artifactId>EcoEgg</artifactId>
-    <version>1.2</version>
+    <version>1.3</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/jp/minecraftuser/ecoegg/SimpleTradeRecipe.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/SimpleTradeRecipe.java
@@ -13,6 +13,8 @@ public class SimpleTradeRecipe implements ConfigurationSerializable {
     private ItemStack input_item_0;
     private ItemStack input_item_1;
     private ItemStack output_item;
+    private float priceMultiplier;
+    private int villagerExperience;
 
     public SimpleTradeRecipe(MerchantRecipe recipe) {
         this.input_item_0 = recipe.getIngredients().get(0);
@@ -20,24 +22,34 @@ public class SimpleTradeRecipe implements ConfigurationSerializable {
         this.output_item = recipe.getResult();
         this.uses = recipe.getUses();
         this.max_uses = recipe.getMaxUses();
+        this.priceMultiplier = recipe.getPriceMultiplier();
+        this.villagerExperience = recipe.getVillagerExperience();
     }
 
-    public SimpleTradeRecipe(ItemStack input_item_0, ItemStack input_item_1, ItemStack output_item, int uses, int max_uses) {
+    public SimpleTradeRecipe(ItemStack input_item_0, ItemStack input_item_1, ItemStack output_item, int uses, int max_uses,float priceMultiplier,int villagerExperience) {
         this.input_item_0 = input_item_0;
         this.input_item_1 = input_item_1;
         this.output_item = output_item;
         this.uses = uses;
         this.max_uses = max_uses;
+        this.priceMultiplier = priceMultiplier;
+        this.villagerExperience = villagerExperience;
     }
 
     public MerchantRecipe create_MerchantRecipe() {
-        MerchantRecipe mr = new MerchantRecipe(output_item, uses, max_uses, false);
+        MerchantRecipe mr = new MerchantRecipe(output_item, uses, max_uses, true);
         if (input_item_0 != null) {
             mr.addIngredient(input_item_0);
         }
         if (input_item_1 != null) {
             mr.addIngredient(input_item_1);
         }
+        mr.setPriceMultiplier(priceMultiplier);
+        //経験値量が0の場合は村人の経験値が増えなくなってしまうため､1を設定する
+        if(villagerExperience == 0){
+            villagerExperience = 1;
+        }
+        mr.setVillagerExperience(villagerExperience);
         return mr;
     }
 
@@ -50,6 +62,8 @@ public class SimpleTradeRecipe implements ConfigurationSerializable {
         map.put("output_item", output_item.serialize());
         map.put("uses", uses);
         map.put("max_uses", max_uses);
+        map.put("price_multiplier",priceMultiplier);
+        map.put("villager_experience",villagerExperience);
         return map;
     }
 
@@ -59,9 +73,14 @@ public class SimpleTradeRecipe implements ConfigurationSerializable {
         ItemStack output_item = ItemStack.deserialize((Map<String, Object>) trade.get("output_item"));
         int uses = Integer.parseInt(String.valueOf(trade.get("uses")));
         int max_uses = Integer.parseInt(String.valueOf(trade.get("max_uses")));
-
-        return new SimpleTradeRecipe(input_item_0, input_item_1, output_item, uses, max_uses);
-
-
+        float price_multiplier = 0;
+        if(trade.containsKey("price_multiplier")){
+            price_multiplier = Float.parseFloat(String.valueOf(trade.get("price_multiplier")));
+        }
+        int villager_experience = 0;
+        if(trade.containsKey("villager_experience")){
+            villager_experience = Integer.parseInt(String.valueOf(trade.get("villager_experience")));
+        }
+        return new SimpleTradeRecipe(input_item_0, input_item_1, output_item, uses, max_uses,price_multiplier,villager_experience);
     }
 }

--- a/src/main/java/jp/minecraftuser/ecoegg/config/LoaderMob.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/config/LoaderMob.java
@@ -359,6 +359,12 @@ public class LoaderMob extends LoaderYaml {
         list.set("villagerlevel", villagerlevel);
         saveCnf();
     }
+    public int getVillagerExperience() { return list.getInt("villagerexperience"); }
+
+    public void setVillagerExperience(int villagerexperience) {
+        list.set("villagerexperience",villagerexperience);
+        saveCnf();
+    }
 
     public boolean getChild() {
         return list.getBoolean("child");

--- a/src/main/java/jp/minecraftuser/ecoegg/mob/CreateMob.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/mob/CreateMob.java
@@ -57,8 +57,8 @@ public class CreateMob {
         entity = (LivingEntity) player.getWorld().spawnEntity(loc, entityType);
         try {
             if (material == Material.SOUL_SAND) {
-            Utl.sendPluginMessage(plg, player, "ノーマルのモンスターエッグとして使用しました");
-            return entity;
+                Utl.sendPluginMessage(plg, player, "ノーマルのモンスターエッグとして使用しました");
+                return entity;
             }
 
 
@@ -100,16 +100,16 @@ public class CreateMob {
             if (entity instanceof TropicalFish) {
                 createTropical_Fish();
             }
-            if(entity instanceof Panda){
+            if (entity instanceof Panda) {
                 createPanda();
             }
-            if(entity instanceof Cat){
+            if (entity instanceof Cat) {
                 createCat();
             }
-            if(entity instanceof Fox){
+            if (entity instanceof Fox) {
                 createFox();
             }
-            if(entity instanceof MushroomCow ){
+            if (entity instanceof MushroomCow) {
                 createMushroomCow();
             }
 
@@ -125,10 +125,9 @@ public class CreateMob {
             if (entity instanceof Zombie || entity instanceof Skeleton) {
                 createEntityEquipment();
             }
-
             createPotionEffect();
-        }catch (Exception e){
-            if(!isOldFormatEgg()) {
+        } catch (Exception e) {
+            if (!isOldFormatEgg()) {
                 //復元に失敗した場合はキャンセルする
                 plg.getLogger().log(Level.SEVERE, "Mobの復元に失敗しました");
                 e.printStackTrace();
@@ -250,56 +249,69 @@ public class CreateMob {
             trade_list.add(merchantRecipe);
         });
 
+        Villager.Profession villagerProfession = null;
+        int villagerLevel = 0;
+        int villagerExperience = 0;
+
         if (Version.compare("1.0", load.getPluginVersion())) {
-            villager.setProfession(load.getVillagerProfession());
-            villager.setVillagerLevel(Math.max(Math.min(load.getVillagerLevel(),5),1));
+            villagerProfession = load.getVillagerProfession();
+            villagerLevel = load.getVillagerLevel();
+            if (Version.compare("1.3", load.getPluginVersion())) {
+                villagerExperience = load.getVillagerExperience();
+            }
         } else {
-
-            Utl.sendPluginMessage(plg, player, "1.15以前の村人です変換処理を行います");
-
+            Utl.sendPluginMessage(plg, player, "1.15以前の村人です､変換処理を行います");
             String old_profession = load.getVillagerCareer();
-            String new_profession = "";
-
-            int old_level = load.getVillagerCareerLevel();
-            int new_level = 0;
-
             switch (old_profession) {
                 case "WEAPON_SMITH":
-                    new_profession = "WEAPONSMITH";
+                    villagerProfession = Villager.Profession.valueOf("WEAPONSMITH");
                     break;
                 case "TOOL_SMITH":
-                    new_profession = "TOOLSMITH";
+                    villagerProfession = Villager.Profession.valueOf("TOOLSMITH");
                     break;
                 default:
-                    new_profession = old_profession;
+                    villagerProfession = Villager.Profession.valueOf(old_profession);
             }
-            new_level = Math.max(Math.min(old_level,5),1);
 
-            Utl.sendPluginMessage(plg, player, "profession: " + old_profession + "->" + new_profession );
-            Utl.sendPluginMessage(plg, player, "level: " + old_level + "->" + new_level );
-            villager.setProfession(Villager.Profession.valueOf(new_profession));
-            villager.setVillagerLevel(new_level);
-
+            villagerLevel = load.getVillagerCareerLevel();
+            Utl.sendPluginMessage(plg, player, "profession: " + old_profession + "->" + villagerProfession);
 
         }
+        //1~5の範囲に収めないとエラーが発生するので設定
+        if (villagerLevel <= 0 || villagerLevel >= 6) {
+            int oldVillagerLevel = villagerLevel;
+            villagerLevel = Math.max(Math.min(villagerLevel, 5), 1);
+            Utl.sendPluginMessage(plg, player, "VillagerLevel: " + oldVillagerLevel + "->" + villagerLevel);
+        }
+        //villagerExperience復元用処理､Level1=0,2=10,3=50,4=100,5=150
+        if (villagerExperience == 0) {
+            int oldVillagerExperience = villagerExperience;
+            int[] exp = {0, 0, 10, 50, 100, 150};
+            villagerExperience = exp[villagerLevel];
+            Utl.sendPluginMessage(plg, player, "VillagerExperience: " + oldVillagerExperience + "->" + villagerExperience);
+        }
+        villager.setProfession(villagerProfession);
+        villager.setVillagerExperience(villagerExperience);
+        villager.setVillagerLevel(villagerLevel);
 
         villager.setRecipes(trade_list);
     }
-    private void createPanda(){
-        Panda panda = (Panda)entity;
+
+    private void createPanda() {
+        Panda panda = (Panda) entity;
         panda.setMainGene(load.getPandaMainGene());
         panda.setHiddenGene(load.getPandaHiddenGene());
     }
 
-    private void createCat(){
-        Cat cat = (Cat)entity;
+    private void createCat() {
+        Cat cat = (Cat) entity;
         cat.setCatType(load.getCatType());
         cat.setCollarColor(load.getDyeColor());
     }
 
 
-    private void createFox(){
-        Fox fox = (Fox)entity;
+    private void createFox() {
+        Fox fox = (Fox) entity;
         boolean ownerreset = false;
         String firstTrustedPlayer = load.getFoxFirstTrustedPlayer();
         String secondTrustedPlayer = load.getFoxSecondTrustedPlayer();
@@ -307,24 +319,24 @@ public class CreateMob {
 
         if (material == Material.CARROTS) ownerreset = true;
 
-        if(ownerreset){
+        if (ownerreset) {
             fox.setFirstTrustedPlayer(player);
-        }else{
-            if(firstTrustedPlayer != null){
+        } else {
+            if (firstTrustedPlayer != null) {
                 fox.setFirstTrustedPlayer(plg.getServer().getOfflinePlayer(firstTrustedPlayer));
             }
-            if(secondTrustedPlayer != null){
+            if (secondTrustedPlayer != null) {
                 fox.setSecondTrustedPlayer(plg.getServer().getOfflinePlayer(secondTrustedPlayer));
             }
         }
     }
 
-    private void createMushroomCow(){
+    private void createMushroomCow() {
         if (Version.compare("1.0", load.getPluginVersion())) {
             MushroomCow mushroomCow = (MushroomCow) entity;
             mushroomCow.setVariant(load.getMushroomCowVariant());
-        }else {
-            Utl.sendPluginMessage(plg,player,"MushroomCowVariant 復元処理をスキップしました");
+        } else {
+            Utl.sendPluginMessage(plg, player, "MushroomCowVariant 復元処理をスキップしました");
         }
 
     }

--- a/src/main/java/jp/minecraftuser/ecoegg/mob/InfoMob.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/mob/InfoMob.java
@@ -186,6 +186,8 @@ public class InfoMob {
             trade_recipe.append(resultItem.getType()).append(" * ").append(resultItem.getAmount());
             trade_recipe.append("(").append(merchantRecipe.getUses()).append("/").append(merchantRecipe.getMaxUses()).append(")");
             Utl.sendPluginMessage(plg, player, trade_recipe.toString());
+            Utl.sendPluginMessage(plg,player,"PriceMultiplier :"+merchantRecipe.getPriceMultiplier());
+            Utl.sendPluginMessage(plg,player,"VillagerExperience :"+merchantRecipe.getVillagerExperience());
         });
         Utl.sendPluginMessage(plg, player, "----トレード内容ここまで----");
 
@@ -196,6 +198,7 @@ public class InfoMob {
             Utl.sendPluginMessage(plg, player, "取引を更新すると職業を取得できます");
             return;
         }
+        Utl.sendPluginMessage(plg, player, "VillagerExperience" + villager.getVillagerExperience());
         Utl.sendPluginMessage(plg, player, "VillagerLevel:" + villager.getVillagerLevel());
 
     }

--- a/src/main/java/jp/minecraftuser/ecoegg/mob/SaveMob.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/mob/SaveMob.java
@@ -203,6 +203,7 @@ public class SaveMob {
             cancel = true;
             return;
         }
+        save.setVillagerExperience(villager.getVillagerExperience());
         save.setVillagerLevel(villager.getVillagerLevel());
 
     }


### PR DESCRIPTION
1.孵化後に取引を行ってもプレイヤーに経験値が入らない

2.孵化後に取引を行っても村人の経験値がたまらない
*取引EXP(villager_experience)を設定していなかったことが原因
保存･設定を行うよう修正､また取引EXPが0だった場合は1を設定(1.13.2 -> 1.15.2 Convertと同様)

3.孵化後に取引の割引が発生しない
*割引率(price_multiplier)を設定していなかったことが原因
保存･設定を行うよう修正､また割引率が設定されていない場合は0を設定(1.13.2 -> 1.15.2 Convertと同様)

4.孵化後に村人の経験値が設定されない(レベルは設定される)
*レベルを元に経験値を設定するように変更｡
保存･設定を行うよう修正､また経験値が設定されていない場合は現在のレベルをもとに経験値を設定するよう修正