### PR TITLE
村人が職業ブロックに紐づかないバグを改善

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>jp.minecraftuser</groupId>
     <artifactId>EcoEgg</artifactId>
-    <version>1.9</version>
+    <version>1.10</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/jp/minecraftuser/ecoegg/command/EceInfoEggCommand.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/command/EceInfoEggCommand.java
@@ -69,7 +69,7 @@ public class EceInfoEggCommand extends CommandFrame {
         // MOBのyaml情報を取得
         LoaderMob load = new LoaderMob((EcoEgg) plg, new UUID(Long.parseLong(most), Long.parseLong(least)));
 
-        CreateMob createMob = new CreateMob(player, Material.STONE, player.getLocation(), load, plg);
+        CreateMob createMob = new CreateMob(player, Material.STONE, player.getLocation(), player.getLocation(), load, plg);
         LivingEntity entity = createMob.create();
 
         InfoMob infoMob = new InfoMob(entity, player, plg);

--- a/src/main/java/jp/minecraftuser/ecoegg/listener/HatchingListener.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/listener/HatchingListener.java
@@ -327,15 +327,15 @@ public class HatchingListener extends ListenerFrame {
 
 
         // MOBスポーン処理
-
         Location loc = block.getLocation();
+        Location site_loc = block.getLocation();
         BlockFace blockface = event.getBlockFace();
 
         loc.add(blockface.getModX(), blockface.getModY(), blockface.getModZ());
         loc.setX(loc.getX() + 0.5);
         loc.setZ(loc.getZ() + 0.5);
 
-        CreateMob createMob = new CreateMob(player, block.getType(), loc, load, plg);
+        CreateMob createMob = new CreateMob(player, block.getType(), loc, site_loc, load, plg);
         LivingEntity livingEntity = createMob.create();
         if (createMob.isCancel()) {
             Utl.sendPluginMessage(plg, event.getPlayer(), "モンスター復元処理に失敗しました");

--- a/src/main/java/jp/minecraftuser/ecoegg/mob/CreateMob.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/mob/CreateMob.java
@@ -6,6 +6,7 @@ import jp.minecraftuser.ecoegg.Version;
 import jp.minecraftuser.ecoegg.config.LoaderMob;
 import jp.minecraftuser.ecoframework.PluginFrame;
 import jp.minecraftuser.ecoframework.Utl;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.attribute.Attribute;
@@ -25,14 +26,16 @@ public class CreateMob {
     private Player player;
     private Material material;
     private Location loc;
+    private Location site_loc;
     private LoaderMob load;
     private PluginFrame plg;
     private boolean cancel = false;
 
-    public CreateMob(Player player, Material material, Location loc, LoaderMob load, PluginFrame plg) {
+    public CreateMob(Player player, Material material, Location loc, Location site_loc, LoaderMob load, PluginFrame plg) {
         this.player = player;
         this.material = material;
         this.loc = loc;
+        this.site_loc = site_loc;
         this.load = load;
         this.plg = plg;
     }
@@ -63,9 +66,9 @@ public class CreateMob {
 
 
             entity.setMaxHealth(load.getMaxHealth());
-            if(load.getHealth() <= 1){
+            if (load.getHealth() <= 1) {
                 entity.setHealth(1);
-            }else{
+            } else {
                 entity.setHealth(load.getHealth());
             }
 
@@ -118,10 +121,10 @@ public class CreateMob {
                 createMushroomCow();
             }
             //ウーパールーパー
-            if (entity instanceof Axolotl){
+            if (entity instanceof Axolotl) {
                 createAxolotl();
             }
-            if (entity instanceof Frog){
+            if (entity instanceof Frog) {
                 createFrog();
             }
 
@@ -306,6 +309,17 @@ public class CreateMob {
         villager.setProfession(villagerProfession);
         villager.setVillagerExperience(villagerExperience);
         villager.setVillagerLevel(villagerLevel);
+
+        //カーソルを当てているブロックを職業ブロックに設定する
+        //関係ないブロックの場合は反映されない模様
+        long mostSigBits = villager.getUniqueId().getMostSignificantBits();
+        long leastSigBits = villager.getUniqueId().getLeastSignificantBits();
+        String UUID_NBT = "[I;" + (int) (mostSigBits >> 32) + "," + (int) mostSigBits + "," + (int) (leastSigBits >> 32) + "," + (int) leastSigBits + "]";
+        int site_loc_x = site_loc.getBlockX();
+        int site_loc_Y = site_loc.getBlockY();
+        int site_loc_z = site_loc.getBlockZ();
+        String command = "data merge entity @e[nbt={UUID:" + UUID_NBT + "},limit=1] {Brain:{memories:{\"minecraft:job_site\":{value:{pos:[I;" + site_loc_x + "," + site_loc_Y + "," + site_loc_z + "]}}}}}";
+        Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command);
 
         villager.setRecipes(trade_list);
     }

--- a/src/main/java/jp/minecraftuser/ecoegg/mob/InfoMob.java
+++ b/src/main/java/jp/minecraftuser/ecoegg/mob/InfoMob.java
@@ -3,6 +3,7 @@ package jp.minecraftuser.ecoegg.mob;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.*;
 
+import org.bukkit.entity.memory.MemoryKey;
 import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.inventory.ItemStack;
 
@@ -207,6 +208,10 @@ public class InfoMob {
         }
         Utl.sendPluginMessage(plg, player, "VillagerExperience" + villager.getVillagerExperience());
         Utl.sendPluginMessage(plg, player, "VillagerLevel:" + villager.getVillagerLevel());
+
+        Utl.sendPluginMessage(plg, player, "JOB_SITE:" + villager.getMemory(MemoryKey.JOB_SITE));
+        Utl.sendPluginMessage(plg, player, "VillagerHome:" + villager.getMemory(MemoryKey.HOME));
+
 
     }
 


### PR DESCRIPTION
えこたまご(モンスターエッグ)使用時に 近くにある職業ブロックに村人が紐づかないバグを修正

修正内容
えこたまご(モンスターエッグ)を使用する際、カーソルを当てたブロック座標を取得し、
その座標のブロックを村人の職業ブロックに割り当てます。
割当にはnbtタグの変更が必要ですが、該当のnbtタグは直接いじれないため、
コマンド経由でnbtタグを編集しています。

(カーソルを当てたブロックが職業ブロックでない場合は、反映されない模様)

紐づいているかの有無は/ece infoコマンドのJOB_SITEで確認できます。
紐づいていれば座標が表示されます。
紐づいていなければnullが表示されます。

